### PR TITLE
[BE -#18, #19]공통 응답 및 예약, 스케줄 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/IceStudyRoomApplication.java
+++ b/backend/src/main/java/com/ice/studyroom/IceStudyRoomApplication.java
@@ -9,5 +9,4 @@ public class IceStudyRoomApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(IceStudyRoomApplication.class, args);
 	}
-
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/api/ReservationController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/api/ReservationController.java
@@ -1,8 +1,12 @@
 package com.ice.studyroom.domain.reservation.api;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,9 +14,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ice.studyroom.domain.reservation.application.ReservationService;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
 import com.ice.studyroom.domain.reservation.dto.request.CreateReservationRequest;
 import com.ice.studyroom.domain.reservation.dto.request.DeleteReservationRequest;
 import com.ice.studyroom.domain.reservation.dto.response.ReservationResponse;
+import com.ice.studyroom.global.dto.response.ResponseDto;
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.StatusCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,25 +37,43 @@ public class ReservationController {
 
 	private final ReservationService reservationService;
 
+	@GetMapping("/schedules")
+	public ResponseEntity<List<Schedule>> getSchedules() {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(reservationService.getSchedules());
+	}
+
+	@ExceptionHandler(BusinessException.class)
+	@GetMapping("/reservations")
+	public ResponseEntity<ResponseDto<List<Reservation>>> getReservations() {
+		return ResponseEntity
+			.status(StatusCode.OK.getStatus())
+			.body(ResponseDto.of(reservationService.getReservations()));
+	}
+
 	@Operation(summary = "스터디룸 예약", description = "스터디룸을 예약합니다.")
 	@ApiResponse(responseCode = "201", description = "스터디룸 예약 성공")
 	@PostMapping("/reservations")
-	public ResponseEntity<ReservationResponse> createReservation(
+	public ResponseEntity<ResponseDto<ReservationResponse>> createReservation(
 		@Valid @RequestBody CreateReservationRequest request
 	) {
 		return ResponseEntity
-			.status(HttpStatus.CREATED)
-			.body(reservationService.createReservation(request));
+			.status(StatusCode.OK.getStatus())
+			.body(ResponseDto.of(reservationService.createReservation(request)));
 	}
 
 	@Operation(summary = "예약 삭제", description = "예약을 삭제합니다.")
 	@DeleteMapping("/reservations/{id}")
-	public ResponseEntity<Void> deleteReservation(@PathVariable Long id) {
+	public ResponseEntity<ResponseDto<Void>> deleteReservation(@PathVariable Long id) {
 		DeleteReservationRequest request = DeleteReservationRequest.builder()
 			.reservationId(id)
 			.userId(1L)  // 모킹했으니 무시해도 됩니다. 추후 회원가입 때 구현 예정
 			.build();
 		reservationService.cancelReservation(request);
-		return ResponseEntity.ok().build();
+
+		return ResponseEntity
+			.status(StatusCode.OK.getStatus())
+			.body(ResponseDto.<Void>of(null, "예약이 성공적으로 삭제되었습니다"));
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -1,5 +1,6 @@
 package com.ice.studyroom.domain.reservation.application;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,18 @@ public class ReservationService {
 	private final TimeSlotRepository timeSlotRepository;
 	private final RoomRepository roomRepository;
 	private final ScheduleRepository scheduleRepository;
+
+	public List<Reservation> getReservations() {
+		// 오늘 날짜에 해당하는 스케줄만 산출
+		LocalDate today = LocalDate.now();
+		return reservationRepository.findByScheduleDate(today);
+	}
+
+	public List<Schedule> getSchedules() {
+		// 오늘 날짜에 해당하는 스케줄만 산출
+		LocalDate today = LocalDate.now();
+		return scheduleRepository.findByScheduleDate(today);
+	}
 
 	@Transactional
 	public ReservationResponse createReservation(CreateReservationRequest request) {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/dao/ReservationRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/dao/ReservationRepository.java
@@ -1,8 +1,12 @@
 package com.ice.studyroom.domain.reservation.dao;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+	List<Reservation> findByScheduleDate(LocalDate date);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/dao/ScheduleRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/dao/ScheduleRepository.java
@@ -1,8 +1,12 @@
 package com.ice.studyroom.domain.reservation.dao;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+	List<Schedule> findByScheduleDate(LocalDate date);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Schedule.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Schedule.java
@@ -3,8 +3,6 @@ package com.ice.studyroom.domain.reservation.domain.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.ice.studyroom.domain.reservation.domain.type.ScheduleStatus;
 import com.ice.studyroom.domain.reservation.dto.request.CreateScheduleRequest;
@@ -17,8 +15,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -71,12 +67,7 @@ public class Schedule {
 	@Column(nullable = false)
 	@Builder.Default
 	private LocalDateTime updatedAt = LocalDateTime.now();
-
-	@OneToMany
-	@JoinColumn(name = "schedule_id")
-	@Builder.Default
-	private List<Reservation> reservations = new ArrayList<>();
-
+	
 	public boolean isAvailable() {
 		return status == ScheduleStatus.AVAILABLE;
 	}

--- a/backend/src/main/java/com/ice/studyroom/global/dto/response/ResponseDto.java
+++ b/backend/src/main/java/com/ice/studyroom/global/dto/response/ResponseDto.java
@@ -1,0 +1,86 @@
+package com.ice.studyroom.global.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.ice.studyroom.global.type.StatusCode;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResponseDto<T> {
+	private String code;
+	private String message;
+
+	private T data;
+	private List<FieldError> errors;
+	private LocalDateTime timestamp;
+
+	@Getter
+	@Builder
+	public static class FieldError {
+		private String field; // 에러 필드명
+		private String value; // 에러 값
+		private String reason; // 에러 이유
+	}
+
+	// 성공 응답 (기본)
+	public static <T> ResponseDto<T> of(T data) {
+		return ResponseDto.<T>builder()
+			.code(StatusCode.OK.getCode())
+			.message(StatusCode.OK.getMessage())
+			.data(data)
+			.timestamp(LocalDateTime.now())
+			.build();
+	}
+
+	// 성공 응답 (메시지 포함)
+	public static <T> ResponseDto<T> of(T data, String message) {
+		return ResponseDto.<T>builder()
+			.code(StatusCode.OK.getCode())
+			.message(message)
+			.data(data)
+			.timestamp(LocalDateTime.now())
+			.build();
+	}
+
+	// 성공 응답 (상태 코드 지정)
+	public static <T> ResponseDto<T> of(StatusCode statusCode, T data) {
+		return ResponseDto.<T>builder()
+			.code(statusCode.getCode())
+			.message(statusCode.getMessage())
+			.data(data)
+			.timestamp(LocalDateTime.now())
+			.build();
+	}
+
+	// 에러 응답 (기본)
+	public static <T> ResponseDto<T> error(StatusCode statusCode) {
+		return ResponseDto.<T>builder()
+			.code(statusCode.getCode())
+			.message(statusCode.getMessage())
+			.timestamp(LocalDateTime.now())
+			.build();
+	}
+
+	// 에러 응답 (메시지 포함)
+	public static <T> ResponseDto<T> error(StatusCode statusCode, String message) {
+		return ResponseDto.<T>builder()
+			.code(statusCode.getCode())
+			.message(message)
+			.timestamp(LocalDateTime.now())
+			.build();
+	}
+
+	// 에러 응답 (필드 에러 포함)
+	public static <T> ResponseDto<T> error(StatusCode statusCode, List<FieldError> errors) {
+		return ResponseDto.<T>builder()
+			.code(statusCode.getCode())
+			.message(statusCode.getMessage())
+			.errors(errors)
+			.timestamp(LocalDateTime.now())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.ice.studyroom.global.exception;
+
+import com.ice.studyroom.global.type.StatusCode;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+	private final StatusCode statusCode;
+
+	public BusinessException(StatusCode statusCode) {
+		super(statusCode.getMessage());
+		this.statusCode = statusCode;
+	}
+
+	public BusinessException(StatusCode statusCode, String message) {
+		super(message);
+		this.statusCode = statusCode;
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,78 @@
+package com.ice.studyroom.global.exception;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.ice.studyroom.global.dto.response.ResponseDto;
+import com.ice.studyroom.global.type.StatusCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+	// JSON 파싱/타입 변환 실패 시
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	protected ResponseEntity<ResponseDto<Object>> handleHttpMessageNotReadable(
+		HttpMessageNotReadableException ex) {
+
+		// 상세 에러는 로그로만 남김
+		log.error("Message not readable exception occurred", ex);
+
+		// 클라이언트에는 최소한의 정보만 전달
+		return ResponseEntity
+			.status(StatusCode.BAD_REQUEST.getStatus())
+			.body(ResponseDto.error(
+				StatusCode.BAD_REQUEST,
+				"Invalid request format"  // 일반적인 메시지만 전달
+			));
+	}
+
+	// Bean Validation 예외 처리도 수정
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<ResponseDto<Object>> handleMethodArgumentNotValid(
+		MethodArgumentNotValidException ex) {
+		// 로그에는 상세 정보 포함
+		log.error("Validation error occurred: {}", ex.getBindingResult());
+
+		// 필드 에러는 포함하되, 최소한의 정보만
+		List<ResponseDto.FieldError> errors = ex.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.map(error -> ResponseDto.FieldError.builder()
+				.field(error.getField())
+				// 거부된 값은 로깅만 하고 응답에는 포함하지 않음
+				//.value(String.valueOf(error.getRejectedValue()))
+				.reason(error.getDefaultMessage())
+				.build())
+			.collect(Collectors.toList());
+
+		return ResponseEntity
+			.status(StatusCode.INVALID_INPUT.getStatus())
+			.body(ResponseDto.error(StatusCode.INVALID_INPUT, errors));
+	}
+
+	// 비즈니스 예외 처리
+	@ExceptionHandler(BusinessException.class)
+	protected ResponseEntity<ResponseDto<Object>> handleBusinessException(BusinessException ex) {
+		return ResponseEntity
+			.status(ex.getStatusCode().getStatus())
+			.body(ResponseDto.error(ex.getStatusCode(), ex.getMessage()));
+	}
+
+	// 일반 예외 처리
+	@ExceptionHandler(Exception.class)
+	protected ResponseEntity<ResponseDto<Object>> handleException(Exception ex) {
+		log.error("Unhandled exception occurred", ex);
+		return ResponseEntity
+			.status(StatusCode.INTERNAL_ERROR.getStatus())
+			.body(ResponseDto.error(StatusCode.INTERNAL_ERROR));
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/global/type/StatusCode.java
+++ b/backend/src/main/java/com/ice/studyroom/global/type/StatusCode.java
@@ -1,0 +1,31 @@
+package com.ice.studyroom.global.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StatusCode {
+	// Success
+	OK(200, "S200", "Success"),
+	CREATED(201, "S201", "Created Success"),
+
+	// Client Errors
+	BAD_REQUEST(400, "C400", "Bad Request"),
+	UNAUTHORIZED(401, "C401", "Unauthorized"),
+	FORBIDDEN(403, "C403", "Forbidden"),
+	NOT_FOUND(404, "C404", "Not Found"),
+
+	// Business Errors
+	INVALID_INPUT(400, "B400", "Invalid Input Data"),
+	DUPLICATE_ENTRY(400, "B401", "Duplicate Entry"),
+	INSUFFICIENT_BALANCE(400, "B402", "Insufficient Balance"),
+
+	// Server Errors
+	INTERNAL_ERROR(500, "E500", "Internal Server Error"),
+	SERVICE_UNAVAILABLE(503, "E503", "Service Unavailable");
+
+	private final int status;
+	private final String code;
+	private final String message;
+}


### PR DESCRIPTION
## PR 종류
- [x] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- 공통 응답 처리를 통한 프론트엔드 데이터 통일성 향상
- 예약, 스케줄 조회 API 구현

## 관련 이슈
- #18
- #19 

## 체크리스트
- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/8aefad05-c5f4-4788-be95-88d91d793c4b" />
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/bf78938d-46e0-474a-aaa8-e17803b47e5d" />

## 기타
테스트 코드 학습하고 있으니, 다음 PR에 추가할 예정입니다.