### PR TITLE
[BE -#46] 토큰 재발급 구현

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/identity/exception/InvalidRefreshTokenException.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.ice.studyroom.domain.identity.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+	public InvalidRefreshTokenException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/MembershipController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/MembershipController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ice.studyroom.domain.membership.application.MembershipService;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberCreateRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberLoginRequest;
+import com.ice.studyroom.domain.membership.presentation.dto.request.TokenRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.response.MemberCreateResponse;
 import com.ice.studyroom.domain.membership.presentation.dto.response.MemberLoginResponse;
 import com.ice.studyroom.global.dto.response.ResponseDto;
@@ -36,5 +37,12 @@ public class MembershipController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(ResponseDto.of(membershipService.login(request)));
+	}
+
+	@PostMapping("refresh")
+	public ResponseEntity<ResponseDto<MemberLoginResponse>> refresh(@Valid @RequestBody TokenRequest request) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ResponseDto.of(membershipService.refresh(request)));
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/request/TokenRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/request/TokenRequest.java
@@ -1,0 +1,11 @@
+package com.ice.studyroom.domain.membership.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TokenRequest(
+	@NotNull(message = "Access Token은 필수입니다.")
+	String accessToken,
+	@NotNull(message = "Refresh Token은 필수입니다.")
+	String refreshToken
+) {
+}


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
레디스로 Refresh 토큰을 관리합니다.
기존에는 Refresh 토큰 자체에 만료기한을 설정해서 전달해줬으나, Redis의 TTL 기능을 사용해서 만료 기한을 관리합니다.
Refresh 토큰을 사용함으로써, 재로그인을 하지않고도 로그인 유지가 가능해집니다.

## 관련 이슈
- #46 

## 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/8a4e2c6e-989e-4dd0-926b-9b1c552b7ec7" />

## 기타
추가로 알려야 할 사항이 있다면 적어주세요.
