### PR TITLE
[BE -#47] 로그아웃 구현

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
@@ -20,8 +20,8 @@ import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepo
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberCreateRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberLoginRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.TokenRequest;
-import com.ice.studyroom.domain.membership.presentation.dto.response.MemberCreateResponse;
 import com.ice.studyroom.domain.membership.presentation.dto.response.MemberLoginResponse;
+import com.ice.studyroom.domain.membership.presentation.dto.response.MemberResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,7 +36,7 @@ public class MembershipService {
 	private final TokenService tokenService;
 	private final AuthenticationManager authenticationManager;
 
-	public MemberCreateResponse createMember(MemberCreateRequest request) {
+	public MemberResponse createMember(MemberCreateRequest request) {
 		memberDomainService.validateEmailUniqueness(Email.of(request.email()));
 
 		Member user = Member.builder()
@@ -51,7 +51,7 @@ public class MembershipService {
 
 		memberRepository.save(user);
 
-		return new MemberCreateResponse("success");
+		return MemberResponse.of("success");
 	}
 
 	public MemberLoginResponse login(MemberLoginRequest request) {
@@ -73,5 +73,13 @@ public class MembershipService {
 		JwtToken jwtToken = tokenService.rotateToken(email, request.refreshToken());
 
 		return MemberLoginResponse.of(jwtToken);
+	}
+
+	public MemberResponse logout(TokenRequest request) {
+		String email = tokenService.extractEmailFromAccessToken(request.accessToken());
+
+		tokenService.deleteToken(email, request.refreshToken());
+
+		return MemberResponse.of("success");
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/MembershipController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/MembershipController.java
@@ -11,8 +11,8 @@ import com.ice.studyroom.domain.membership.application.MembershipService;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberCreateRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberLoginRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.TokenRequest;
-import com.ice.studyroom.domain.membership.presentation.dto.response.MemberCreateResponse;
 import com.ice.studyroom.domain.membership.presentation.dto.response.MemberLoginResponse;
+import com.ice.studyroom.domain.membership.presentation.dto.response.MemberResponse;
 import com.ice.studyroom.global.dto.response.ResponseDto;
 
 import jakarta.validation.Valid;
@@ -25,7 +25,7 @@ public class MembershipController {
 	private final MembershipService membershipService;
 
 	@PostMapping
-	public ResponseEntity<ResponseDto<MemberCreateResponse>> createUser(
+	public ResponseEntity<ResponseDto<MemberResponse>> createUser(
 		@Valid @RequestBody MemberCreateRequest request) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
@@ -44,5 +44,12 @@ public class MembershipController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(ResponseDto.of(membershipService.refresh(request)));
+	}
+
+	@PostMapping("logout")
+	public ResponseEntity<ResponseDto<MemberResponse>> logout(@Valid @RequestBody TokenRequest request) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ResponseDto.of(membershipService.logout(request)));
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberCreateResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberCreateResponse.java
@@ -1,6 +1,0 @@
-package com.ice.studyroom.domain.membership.presentation.dto.response;
-
-public record MemberCreateResponse(
-	String message
-) {
-}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberResponse.java
@@ -1,0 +1,9 @@
+package com.ice.studyroom.domain.membership.presentation.dto.response;
+
+public record MemberResponse(
+	String message
+) {
+	public static MemberResponse of(String message) {
+		return new MemberResponse(message);
+	}
+}


### PR DESCRIPTION
## PR 종류
- [ ] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
로그아웃을 할 경우 레디스에서 관리하던 Refresh Token을 삭제합니다.
이는 해커가 탈취한 Access Token과 Refresh Token으로 재로그인을 할 수 없게 합니다.

## 관련 이슈
- #47 

## 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/886ad1d9-bdb5-472e-a51e-3fcfb7a7d190" />

## 기타
추가로 알려야 할 사항이 있다면 적어주세요.
