### PR TITLE
[BE - #106] member, penalty table 변경에 따른 코드 수정

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
@@ -78,7 +78,7 @@ public class AdminService {
 			.orElseThrow(() -> new IllegalArgumentException("해당 이메일로 회원을 찾을 수 없습니다."));
 
 		// 조건에 맞는 패널티 리스트 조회
-		List<Penalty> penaltyList = penaltyRepository.findByMemberIdAndPenaltyEndAfterAndIsCanceledFalse(
+		List<Penalty> penaltyList = penaltyRepository.findByMemberIdAndPenaltyEndAfter(
 			member.getId(), LocalDateTime.now()
 		);
 
@@ -96,37 +96,37 @@ public class AdminService {
 		Member member = memberRepository.findByEmail(Email.of(request.email()))
 			.orElseThrow(() -> new IllegalArgumentException("해당 이메일로 회원을 찾을 수 없습니다."));
 
-		//패널티 횟수 차감
-		if(member.getPenaltyCount() >= 3) {
-			member.subPenalty(member.getPenaltyCount());
-			member.updatePenalty(false);
-		} else if(member.getPenaltyCount() == 1) {
-			member.subPenalty(member.getPenaltyCount());
-		} else {throw new IllegalStateException("현재 패널티 횟수가 0입니다.");}
+		// //패널티 횟수 차감
+		// if(member.getPenaltyCount() >= 3) {
+		// 	member.subPenalty(member.getPenaltyCount());
+		// 	member.updatePenalty(false);
+		// } else if(member.getPenaltyCount() == 1) {
+		// 	member.subPenalty(member.getPenaltyCount());
+		// } else {throw new IllegalStateException("현재 패널티 횟수가 0입니다.");}
 
 		//변경상태 저장
 		memberRepository.save(member);
 
 		//return
-		return AdminPenaltyControlResponse.of("관리자가 패널티 횟수를 차감했습니다.", member.getPenaltyCount());
+		return AdminPenaltyControlResponse.of("관리자가 패널티 횟수를 차감했습니다.", 1);
 	}
 
 	public AdminPenaltyControlResponse adminAddPenalty(AdminPenaltyRequest request) {
 		Member member = memberRepository.findByEmail(Email.of(request.email()))
 			.orElseThrow(() -> new IllegalArgumentException("해당 이메일로 회원을 찾을 수 없습니다."));
 
-		//패널티 횟수 증가
-		if(member.isPenalty()) {
-			throw new IllegalStateException("현재 이미 사용불가 상태입니다.");
-		} else if(member.getPenaltyCount() >= 3) {
-			member.updatePenalty(true);
-			member.addPenalty(member.getPenaltyCount());
-		} else{member.addPenalty(member.getPenaltyCount());}
+		// //패널티 횟수 증가
+		// if(member.isPenalty()) {
+		// 	throw new IllegalStateException("현재 이미 사용불가 상태입니다.");
+		// } else if(member.getPenaltyCount() >= 3) {
+		// 	member.updatePenalty(true);
+		// 	member.addPenalty(member.getPenaltyCount());
+		// } else{member.addPenalty(member.getPenaltyCount());}
 
 		//변경상태 저장
 		memberRepository.save(member);
 
 		//return
-		return AdminPenaltyControlResponse.of("관리자가 패널티 횟수를 증가했습니다.", member.getPenaltyCount());
+		return AdminPenaltyControlResponse.of("관리자가 패널티 횟수를 증가했습니다.", 1);
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/response/AdminPenaltyRecordResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/response/AdminPenaltyRecordResponse.java
@@ -2,11 +2,13 @@ package com.ice.studyroom.domain.admin.presentation.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.ice.studyroom.domain.membership.domain.type.PenaltyReasonType;
+
 public record AdminPenaltyRecordResponse(
-	String reason,
+	PenaltyReasonType reason,
 	LocalDateTime penaltyEnd
 ) {
-	public static AdminPenaltyRecordResponse of(String reason, LocalDateTime penaltyEnd) {
+	public static AdminPenaltyRecordResponse of(PenaltyReasonType reason, LocalDateTime penaltyEnd) {
 		return new AdminPenaltyRecordResponse(reason, penaltyEnd);
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
@@ -63,11 +63,8 @@ public class Member {
 	@Column(name = "updated_at", nullable = false)
 	private LocalDateTime updatedAt;
 
-	@Column(name = "isPenalty", nullable = false)
+	@Column(name = "is_penalty", nullable = false)
 	private boolean  isPenalty;
-
-	@Column(name = "penalty_count", nullable = false)
-	private Integer penaltyCount;
 
 	@Builder
 	public Member(Email email, String password, String name, String studentNum, List<String> roles) {
@@ -79,25 +76,10 @@ public class Member {
 		this.createdAt = LocalDateTime.now();
 		this.updatedAt = LocalDateTime.now();
 		this.isPenalty = false;
-		this.penaltyCount = 0;
 	}
 
 	public void updatePenalty(boolean isPenalty) {
 		this.isPenalty = isPenalty;
-	}
-
-	public void addPenalty(int penaltyCount) {
-		if(penaltyCount == 2) {
-			throw new IllegalStateException("현재 이미 사용중지 상태입니다.");
-		}
-		this.penaltyCount += 1;
-	}
-
-	public void subPenalty(int penaltyCount) {
-		if(penaltyCount == 0) {
-			throw new IllegalStateException("패널티 횟수가 0이거나 차감할 수 없습니다.");
-		}
-		this.penaltyCount -= 1;
 	}
 
 	public static Member create(Email email, String name, String rawPassword, String studentNum,
@@ -111,7 +93,6 @@ public class Member {
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.isPenalty(false)
-			.penaltyCount(0)
 			.build();
 	}
 

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Penalty.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Penalty.java
@@ -14,6 +14,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -24,7 +25,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "penalty")
+@Table(
+	name = "penalty",
+	indexes = {
+		@Index(name = "idx_penalty_member_penalty_end", columnList = "member_id, penalty_end")
+	}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Penalty.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Penalty.java
@@ -2,10 +2,14 @@ package com.ice.studyroom.domain.membership.domain.entity;
 
 import java.time.LocalDateTime;
 
+import com.ice.studyroom.domain.membership.domain.type.PenaltyStatus;
+import com.ice.studyroom.domain.membership.domain.type.PenaltyReasonType;
 import com.ice.studyroom.global.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,21 +39,22 @@ public class Penalty extends BaseTimeEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
+	@Enumerated(EnumType.STRING)
 	@Column(name = "reason", nullable = false)
-	private String reason;
+	private PenaltyReasonType reason;
 
 	@Column(name = "penalty_end", nullable = false)
 	private LocalDateTime penaltyEnd;
 
-	//패널티 무효 속성
-	@Column(name = "is_canceled", nullable = false)
-	private boolean isCanceled;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false)
+	@Builder.Default
+	private PenaltyStatus status = PenaltyStatus.VALID;
 
 	@Builder
-	public Penalty(Member member, String reason, LocalDateTime penaltyEnd) {
+	public Penalty(Member member, PenaltyReasonType reason, LocalDateTime penaltyEnd) {
 		this.member = member;
 		this.reason = reason;
 		this.penaltyEnd = penaltyEnd;
-		this.isCanceled = false;
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/type/PenaltyReasonType.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/type/PenaltyReasonType.java
@@ -1,0 +1,7 @@
+package com.ice.studyroom.domain.membership.domain.type;
+
+public enum PenaltyReasonType {
+	CANCEL,
+	LATE,
+	NO_SHOW
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/type/PenaltyStatus.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/type/PenaltyStatus.java
@@ -1,0 +1,6 @@
+package com.ice.studyroom.domain.membership.domain.type;
+
+public enum PenaltyStatus {
+	VALID,
+	EXPIRED
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/infrastructure/persistence/PenaltyRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/infrastructure/persistence/PenaltyRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
-	Long countByMemberIdAndPenaltyEndAfter(Long memberId, LocalDateTime currentTime);
+	Optional<Penalty> findTopByMemberIdAndPenaltyEndAfterOrderByPenaltyEndDesc(Long memberId, LocalDateTime currentTime);
 	List<Penalty> findByMemberIdAndPenaltyEndAfter(Long memberId, LocalDateTime currentTime);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/infrastructure/persistence/PenaltyRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/infrastructure/persistence/PenaltyRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
 	Long countByMemberIdAndPenaltyEndAfter(Long memberId, LocalDateTime currentTime);
-	List<Penalty> findByMemberIdAndPenaltyEndAfterAndIsCanceledFalse(Long memberId, LocalDateTime currentTime);
+	List<Penalty> findByMemberIdAndPenaltyEndAfter(Long memberId, LocalDateTime currentTime);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateScheduler.java
@@ -24,10 +24,14 @@ public class PenaltyUpdateScheduler {
 
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *") // 매일 00:00에 실행
-	public void updatePenaltyCounts() {
+	public void updateMemberPenalty() {
 		memberRepository.findAll().forEach(member -> {
-			Long penaltyCount = penaltyRepository.countByMemberIdAndPenaltyEndAfter(member.getId(), LocalDateTime.now());
-			member.updatePenalty(penaltyCount >= 2);
+			boolean hasPenalty = penaltyRepository
+				.findTopByMemberIdAndPenaltyEndAfterOrderByPenaltyEndDesc(
+				member.getId(), LocalDateTime.now()).isPresent();
+
+
+			member.updatePenalty(hasPenalty);
 		});
 
 		log.info("Penalty counts updated successfully at {}", LocalDateTime.now());

--- a/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.annotation.Rollback;
 
 import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.membership.domain.entity.Penalty;
+import com.ice.studyroom.domain.membership.domain.type.PenaltyReasonType;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.PenaltyRepository;
@@ -46,7 +47,6 @@ class PenaltyUpdateSchedulerTest {
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.isPenalty(false)
-			.penaltyCount(0)
 			.build();
 
 		Member member2 = Member.builder()
@@ -58,30 +58,26 @@ class PenaltyUpdateSchedulerTest {
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
 			.isPenalty(false)
-			.penaltyCount(0)
 			.build();
 
 		memberRepository.saveAll(List.of(member1, member2));
 
 		Penalty penalty1 = Penalty.builder()
 			.member(member1)
-			.reason("Test Penalty 1")
+			.reason(PenaltyReasonType.LATE)
 			.penaltyEnd(LocalDateTime.now().plusDays(1))
-			.isCanceled(false)
 			.build();
 
 		Penalty penalty2 = Penalty.builder()
 			.member(member1)
-			.reason("Test Penalty 2")
+			.reason(PenaltyReasonType.LATE)
 			.penaltyEnd(LocalDateTime.now().plusDays(2))
-			.isCanceled(false)
 			.build();
 
 		Penalty penalty3 = Penalty.builder()
 			.member(member2)
-			.reason("Test Penalty 3")
+			.reason(PenaltyReasonType.LATE)
 			.penaltyEnd(LocalDateTime.now().minusHours(1)) // 만료된 패널티
-			.isCanceled(false)
 			.build();
 
 		penaltyRepository.saveAll(List.of(penalty1, penalty2, penalty3));

--- a/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
@@ -69,30 +69,21 @@ class PenaltyUpdateSchedulerTest {
 			.build();
 
 		Penalty penalty2 = Penalty.builder()
-			.member(member1)
-			.reason(PenaltyReasonType.LATE)
-			.penaltyEnd(LocalDateTime.now().plusDays(2))
-			.build();
-
-		Penalty penalty3 = Penalty.builder()
 			.member(member2)
 			.reason(PenaltyReasonType.LATE)
 			.penaltyEnd(LocalDateTime.now().minusHours(1)) // 만료된 패널티
 			.build();
 
-		penaltyRepository.saveAll(List.of(penalty1, penalty2, penalty3));
+		penaltyRepository.saveAll(List.of(penalty1, penalty2));
 
 		// 2. 스케줄러 실행
-		penaltyUpdateScheduler.updatePenaltyCounts();
+		penaltyUpdateScheduler.updateMemberPenalty();
 
 		// 3. 검증
 		Member updatedMember1 = memberRepository.findById(member1.getId()).orElseThrow();
 		Member updatedMember2 = memberRepository.findById(member2.getId()).orElseThrow();
 
-		// Member1은 유효한 패널티가 2개 이상이므로 isPenalty = true
 		assertThat(updatedMember1.isPenalty()).isTrue();
-
-		// Member2는 유효한 패널티가 없으므로 isPenalty = false
 		assertThat(updatedMember2.isPenalty()).isFalse();
 	}
 }


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 패널티 비즈니스 로직 중 하나인 유효 횟수를 시행하지 않기로 하여, 이에 따른 member, penalty의 DDL을 수정하였습니다.
- penalty 업데이트 스케줄러 코드도 업데이트하였습니다.

## 관련 이슈

#106 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷

필요한 경우 스크린샷을 첨부해주세요.

## 기타

`penalty_end` 를 오름차순으로 인덱스 설정한 이유에 대한 글을 정리했습니다.

https://www.notion.so/penalty_end-f4c47ecffca4429580ae72003058604a
