### PR TITLE
[BE-#31] QR 입실 구현

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/identity/domain/service/QRCodeService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/domain/service/QRCodeService.java
@@ -22,13 +22,14 @@ public class QRCodeService {
 	}
 
 	// 🔹 QR 코드 데이터 저장 (암호화 전 원본을 Key로 저장)
-	public void saveQRCode(String email, String reservationId, String scheduleId, String qrCodeBase64) {
+	public void saveQRCode(String email, Long reservationId, String scheduleId, String qrCodeBase64) {
 		try {
 			String qrKey = "qr:" + email + "_" + reservationId; // 🔹 암호화 전 원본을 Key로 사용
 
 			Map<String, Object> qrData = new HashMap<>();
 			qrData.put("qrCodeBase64", qrCodeBase64);
-			qrData.put("reservationId", reservationId);
+			// 역직렬화 시 Integer로 변환될 것을 방지하기 위해 강제 저장
+			qrData.put("reservationId", reservationId.longValue());
 			qrData.put("email", email);
 			qrData.put("scheduleId", scheduleId);
 			qrData.put("createdAt", Instant.now().toString());
@@ -54,7 +55,22 @@ public class QRCodeService {
 				return null;
 			}
 			Map<String, Object> qrData = objectMapper.readValue(jsonValue, Map.class);
-			return (String)qrData.get("qrCodeBase64"); // 🔹 특정 필드만 반환
+			return (String)qrData.get("qrCodeBase64");
+		} catch (Exception e) {
+			throw new RuntimeException("QR 코드 조회 오류", e);
+		}
+	}
+
+	public Long getResId(String decryptedData) {
+		try {
+			String jsonValue = redisTemplate.opsForValue().get("qr:" + decryptedData);
+			if (jsonValue == null) {
+				return null;
+			}
+			Map<String, Object> qrData = objectMapper.readValue(jsonValue, Map.class);
+
+			Object reservationId = qrData.get("reservationId");
+			return reservationId != null ? ((Number) reservationId).longValue() : null;
 		} catch (Exception e) {
 			throw new RuntimeException("QR 코드 조회 오류", e);
 		}

--- a/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/AESUtil.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/AESUtil.java
@@ -1,6 +1,7 @@
 package com.ice.studyroom.domain.identity.infrastructure.security;
 
 import java.security.spec.KeySpec;
+import java.util.Base64;
 
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -13,19 +14,30 @@ import org.springframework.stereotype.Component;
 @Component
 public class AESUtil {
 
-	private final String secretKey;
+	private final SecretKey secretKey;
+	private final byte[] salt;
 
-	public AESUtil(@Value("${AESUTIL_SECRET_KEY}") String secretKey) {
-		this.secretKey = secretKey;
+	public AESUtil(@Value("${AESUTIL_SECRET_KEY}") String secretKey,
+		@Value("${AESUTIL_SALT}") String salt
+	) {
+		this.secretKey = generateSecretKey(secretKey);
+		this.salt = Base64.getDecoder().decode(salt);
 	}
 
-	public SecretKey generateSecretKey(byte[] salt) {
+	public SecretKey generateSecretKey(String key) {
 		try {
-			SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-			KeySpec spec = new PBEKeySpec(secretKey.toCharArray(), salt, 65536, 256);
-			return new SecretKeySpec(factory.generateSecret(spec).getEncoded(), "AES");
+			byte[] decodedKey = Base64.getDecoder().decode(key);
+			return new SecretKeySpec(decodedKey, "AES");
 		} catch (Exception e) {
 			throw new RuntimeException("키 생성 오류", e);
 		}
+	}
+
+	public SecretKey getSecretKey() {
+		return this.secretKey;
+	}
+
+	public byte[] getSalt() {
+		return this.salt;
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/QRCodeUtil.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/QRCodeUtil.java
@@ -1,6 +1,7 @@
 package com.ice.studyroom.domain.identity.infrastructure.security;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Base64;
 
@@ -9,10 +10,16 @@ import javax.imageio.ImageIO;
 import org.springframework.stereotype.Component;
 
 import com.google.zxing.BarcodeFormat;
+import com.google.zxing.BinaryBitmap;
+import com.google.zxing.LuminanceSource;
+import com.google.zxing.MultiFormatReader;
 import com.google.zxing.MultiFormatWriter;
+import com.google.zxing.Result;
 import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.BufferedImageLuminanceSource;
 import com.google.zxing.client.j2se.MatrixToImageWriter;
 import com.google.zxing.common.BitMatrix;
+import com.google.zxing.common.HybridBinarizer;
 import com.ice.studyroom.domain.identity.domain.service.EncryptionService;
 
 @Component
@@ -25,7 +32,7 @@ public class QRCodeUtil {
 		this.encryptionService = encryptionService;
 	}
 
-	// 🔹 AES-256 암호화 후 QR 코드 생성
+	// AES-256 암호화 후 QR 코드 생성
 	public String generateQRCode(String email, String reservationId) {
 		try {
 			String originalData = email + "_" + reservationId;
@@ -43,8 +50,24 @@ public class QRCodeUtil {
 		}
 	}
 
-	// 🔹 QR 코드 복호화 후 원본 데이터 반환
-	public String decryptQRCode(String encryptedData) {
-		return encryptionService.decrypt(encryptedData);
+	// QR 코드 복호화 후 원본 데이터 반환
+	public String decryptQRCode(String base64QrCode) {
+		try {
+			// Base64 디코딩 → BufferedImage 변환
+			byte[] qrCodeBytes = Base64.getDecoder().decode(base64QrCode);
+			ByteArrayInputStream inputStream = new ByteArrayInputStream(qrCodeBytes);
+			BufferedImage qrImage = ImageIO.read(inputStream);
+
+			// QR 코드 이미지에서 텍스트 추출
+			LuminanceSource source = new BufferedImageLuminanceSource(qrImage);
+			BinaryBitmap bitmap = new BinaryBitmap(new HybridBinarizer(source));
+			Result result = new MultiFormatReader().decode(bitmap);
+			String encryptedData = result.getText();
+
+			// AES-256 복호화
+			return encryptionService.decrypt(encryptedData);
+		} catch (Exception e) {
+			throw new RuntimeException("QR 코드 복호화 오류", e);
+		}
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(
 					"/api/reservations/**",
+					"/api/**", // API 개발을 위한 임시 사용
 					"/api/schedules/**",
 					"/api/users/**",
 					"/api/email/**",  // 이메일 전송 API 경로

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -83,13 +83,12 @@ public class ReservationService {
 		// 얻은 memer_id와 reservation_id를 토대로 예약 레코드를 찾는다.
 		Long memberId = qrCodeService.getResId(qrKey);
 
-		// 예약 레코드의 입실 시간과 퇴실 시간 중 어느시간을 측정해야하는가.  애초에 QR에 입실인지 퇴실인지 해준다면..
 		Reservation reservation = reservationRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다."));
 
 		LocalDateTime now = LocalDateTime.now();
 		ReservationStatus status = reservation.checkAttendanceStatus(now);
-		
+
 		if (status == ReservationStatus.RESERVED) {
 			throw new AttendanceException("출석 시간이 아닙니다.", HttpStatus.FORBIDDEN);
 		} else if (status == ReservationStatus.NO_SHOW) {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -1,6 +1,8 @@
 package com.ice.studyroom.domain.reservation.application;
 
+import java.sql.SQLOutput;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,6 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
@@ -24,12 +27,15 @@ import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
 import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
 import com.ice.studyroom.domain.reservation.domain.type.ScheduleStatus;
 import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
 import com.ice.studyroom.domain.reservation.infrastructure.persistence.ScheduleRepository;
 import com.ice.studyroom.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import com.ice.studyroom.domain.reservation.presentation.dto.request.DeleteReservationRequest;
+import com.ice.studyroom.domain.reservation.presentation.dto.request.QrEntranceRequest;
 import com.ice.studyroom.domain.reservation.presentation.dto.response.GetMostRecentReservationResponse;
+import com.ice.studyroom.global.exception.AttendanceException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -65,6 +71,32 @@ public class ReservationService {
 	public List<Schedule> getSchedule() {
 		LocalDate today = LocalDate.now();
 		return scheduleRepository.findByScheduleDate(today);
+	}
+
+	@Transactional
+	public ReservationStatus qrEntrance(QrEntranceRequest request) {
+		// 이미지를 저장.
+		String qrCode = request.qrCode();
+		// 이 qr 코드가 유효한지와 정보를 얻는다.
+		// 이미지 BASE64디코딩 -> 디코딩 된 이미지 -> 텍스트 추출
+		String qrKey = qrCodeUtil.decryptQRCode(qrCode);
+		// 얻은 memer_id와 reservation_id를 토대로 예약 레코드를 찾는다.
+		Long memberId = qrCodeService.getResId(qrKey);
+
+		// 예약 레코드의 입실 시간과 퇴실 시간 중 어느시간을 측정해야하는가.  애초에 QR에 입실인지 퇴실인지 해준다면..
+		Reservation reservation = reservationRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다."));
+
+		LocalDateTime now = LocalDateTime.now();
+		ReservationStatus status = reservation.checkAttendanceStatus(now);
+		
+		if (status == ReservationStatus.RESERVED) {
+			throw new AttendanceException("출석 시간이 아닙니다.", HttpStatus.FORBIDDEN);
+		} else if (status == ReservationStatus.NO_SHOW) {
+			throw new AttendanceException("출석 시간이 만료되었습니다.", HttpStatus.GONE);
+		}
+
+		return status;
 	}
 
 	// @Transactional
@@ -138,7 +170,7 @@ public class ReservationService {
 
 			// QR 코드 생성 (예약 ID + 이메일 조합)
 			String qrCodeBase64 = qrCodeUtil.generateQRCode(email, reservation.getId().toString());
-			qrCodeService.saveQRCode(email, reservation.getId().toString(), request.scheduleId().toString(), qrCodeBase64);
+			qrCodeService.saveQRCode(email, reservation.getId(), request.scheduleId().toString(), qrCodeBase64);
 			qrCodeMap.put(email, qrCodeBase64);
 		}
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -87,11 +87,7 @@ public class Reservation {
 
 		long minutesDifference = Duration.between(startDateTime, now).toMinutes();
 		long minutesDurationOfReservation = Duration.between(startDateTime, endDateTime).toMinutes();
-		System.out.println("startTime = " + startDateTime);
-		System.out.println("endTime = " + endDateTime);
-		System.out.println("now = " + now);
-		System.out.println("minutesDifference = " + minutesDifference);
-		System.out.println("minutesDurationOfReservation = " + minutesDurationOfReservation);
+
 		if (now.isBefore(startDateTime)) {
 			return ReservationStatus.RESERVED;
 		} else if (minutesDifference <= 30) {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -1,5 +1,6 @@
 package com.ice.studyroom.domain.reservation.domain.entity;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -79,63 +80,36 @@ public class Reservation {
 		return status == ReservationStatus.RESERVED;
 	}
 
-	// 예약 상태 변경 관련 메서드(checkIn(), checkOut(), cancel())
-	public Reservation checkIn() {
-		// validateCheckIn();
-		return Reservation.builder()
-			.id(this.id)
-			.firstScheduleId(this.firstScheduleId)
-			.secondScheduleId(this.secondScheduleId)
-			.userEmail(this.userEmail)
-			.userName(this.userName)
-			.scheduleDate(this.scheduleDate)
-			.roomNumber(this.roomNumber)
-			.startTime(this.startTime)
-			.endTime(this.endTime)
-			.status(ReservationStatus.CHECKED_IN)
-			.enterTime(LocalDateTime.now())
-			.exitTime(this.exitTime)
-			.createdAt(this.createdAt)
-			.updatedAt(LocalDateTime.now())
-			.build();
+	// 정상 입실인지 지각인지 노쇼인지 판단하는 코드
+	public ReservationStatus checkAttendanceStatus(LocalDateTime now) {
+		LocalDateTime startDateTime = LocalDateTime.of(createdAt.toLocalDate(), startTime);
+		LocalDateTime endDateTime = LocalDateTime.of(createdAt.toLocalDate(), endTime);
+
+		long minutesDifference = Duration.between(startDateTime, now).toMinutes();
+		long minutesDurationOfReservation = Duration.between(startDateTime, endDateTime).toMinutes();
+		System.out.println("startTime = " + startDateTime);
+		System.out.println("endTime = " + endDateTime);
+		System.out.println("now = " + now);
+		System.out.println("minutesDifference = " + minutesDifference);
+		System.out.println("minutesDurationOfReservation = " + minutesDurationOfReservation);
+		if (now.isBefore(startDateTime)) {
+			return ReservationStatus.RESERVED;
+		} else if (minutesDifference <= 30) {
+			markStatus(ReservationStatus.ENTRANCE);
+			return ReservationStatus.ENTRANCE;
+		} else if (minutesDifference <= minutesDurationOfReservation) {
+			markStatus(ReservationStatus.LATE);
+			return ReservationStatus.LATE;
+			// 패널티 추가로직
+		} else {
+			return ReservationStatus.NO_SHOW;
+		}
 	}
 
-	public Reservation checkOut() {
-		// validateCheckOut();
-		return Reservation.builder()
-			.id(this.id)
-			.firstScheduleId(this.firstScheduleId)
-			.secondScheduleId(this.secondScheduleId).userEmail(this.userEmail)
-			.userName(this.userName)
-			.scheduleDate(this.scheduleDate)
-			.roomNumber(this.roomNumber)
-			.startTime(this.startTime)
-			.endTime(this.endTime)
-			.status(ReservationStatus.COMPLETED)
-			.enterTime(this.enterTime)
-			.exitTime(LocalDateTime.now())
-			.createdAt(this.createdAt)
-			.updatedAt(LocalDateTime.now())
-			.build();
-	}
-
-	public Reservation cancel() {
-		// validateCancellation();
-		return Reservation.builder()
-			.id(this.id)
-			.firstScheduleId(this.firstScheduleId)
-			.secondScheduleId(this.secondScheduleId).userEmail(this.userEmail)
-			.userName(this.userName)
-			.scheduleDate(this.scheduleDate)
-			.roomNumber(this.roomNumber)
-			.startTime(this.startTime)
-			.endTime(this.endTime)
-			.status(ReservationStatus.RESERVED)
-			.enterTime(this.enterTime)
-			.exitTime(this.exitTime)
-			.createdAt(this.createdAt)
-			.updatedAt(LocalDateTime.now())
-			.build();
+	private void markStatus(ReservationStatus status) {
+		this.status = status;
+		this.enterTime = LocalDateTime.now();
+		this.updatedAt = LocalDateTime.now();
 	}
 
 	public static Reservation from(List<Schedule> schedules, String email, String userName) {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/type/ReservationStatus.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/type/ReservationStatus.java
@@ -3,7 +3,9 @@ package com.ice.studyroom.domain.reservation.domain.type;
 public enum ReservationStatus {
 
 	RESERVED,    // 예약됨
-	CHECKED_IN,  // 입실
-	COMPLETED,   // 이용완료
+	ENTRANCE,
+	LATE,
+	NO_SHOW,
+	EXIT,
 	CANCELLED    // 취소됨
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/QrController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/QrController.java
@@ -15,6 +15,8 @@ import com.ice.studyroom.domain.reservation.presentation.dto.request.QrEntranceR
 import com.ice.studyroom.global.dto.response.ResponseDto;
 import com.ice.studyroom.global.type.StatusCode;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +25,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class QrController {
 	private final ReservationService reservationService;
+
+	@Operation(summary = "예약 QR 코드 인식", description = "QR 코드를 이용하여 입실을 시도합니다.")
+	@ApiResponse(responseCode = "200", description = "정상 출석 혹은 지각")
+	@ApiResponse(responseCode = "403", description = "예약한 스터디룸 시작 시간 이전")
+	@ApiResponse(responseCode = "401", description = "예약한 스터디룸 종료 시간 이후")
 	@PostMapping("/recognize")
 	public ResponseEntity<ResponseDto<ReservationStatus>> qrEntrance(
 		@Valid @RequestBody QrEntranceRequest request) {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/QrController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/QrController.java
@@ -1,0 +1,33 @@
+package com.ice.studyroom.domain.reservation.presentation;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ice.studyroom.domain.reservation.application.ReservationService;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
+import com.ice.studyroom.domain.reservation.presentation.dto.request.QrEntranceRequest;
+import com.ice.studyroom.global.dto.response.ResponseDto;
+import com.ice.studyroom.global.type.StatusCode;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/qr")
+@RequiredArgsConstructor
+public class QrController {
+	private final ReservationService reservationService;
+	@PostMapping("/recognize")
+	public ResponseEntity<ResponseDto<ReservationStatus>> qrEntrance(
+		@Valid @RequestBody QrEntranceRequest request) {
+		return ResponseEntity
+			.status(StatusCode.OK.getStatus())
+			.body(ResponseDto.of(reservationService.qrEntrance(request)));
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/QrEntranceRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/QrEntranceRequest.java
@@ -1,0 +1,9 @@
+package com.ice.studyroom.domain.reservation.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record QrEntranceRequest(
+	@NotBlank(message = "QR Code는 필수입니다.")
+	String qrCode
+) {
+}

--- a/backend/src/main/java/com/ice/studyroom/global/exception/AttendanceException.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/AttendanceException.java
@@ -1,0 +1,19 @@
+package com.ice.studyroom.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class AttendanceException extends RuntimeException {
+	private final HttpStatus status;
+
+	public AttendanceException(String message, HttpStatus status) {
+		super(message);
+		this.status = status;
+	}
+
+	public HttpStatus getStatus() {
+		return status;
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
@@ -59,6 +59,11 @@ public class GlobalExceptionHandler {
 			.body(ResponseDto.error(StatusCode.INVALID_INPUT, errors));
 	}
 
+	@ExceptionHandler(AttendanceException.class)
+	public ResponseEntity<String> handleAttendanceException(AttendanceException ex) {
+		return ResponseEntity.status(ex.getStatus()).body(ex.getMessage());
+	}
+
 	// 비즈니스 예외 처리
 	@ExceptionHandler(BusinessException.class)
 	protected ResponseEntity<ResponseDto<Object>> handleBusinessException(BusinessException ex) {

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/QrRecognitionServiceTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/QrRecognitionServiceTest.java
@@ -1,0 +1,135 @@
+package com.ice.studyroom.domain.reservation.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
+import com.ice.studyroom.helper.ReservationTestHelper;
+
+class QrRecognitionServiceTest {
+
+	private LocalDateTime now;
+
+	@BeforeEach
+	void setup() {
+		now = LocalDateTime.now();
+	}
+
+	/**
+	 * 정해진 입실시간: starTime
+	 * 사용자의 입실시간: enterTime
+	 */
+	@Test
+	void 입실시간_이전_출석() {
+		// given: 출석 시간이 아직 도래하지 않은 경우
+		LocalDateTime startTime = now;
+		LocalDateTime enterTime = startTime.minusMinutes(10);
+		Reservation reservation = ReservationTestHelper.createReservationWithEnterTime(startTime);
+		// when
+		ReservationStatus status = reservation.checkAttendanceStatus(enterTime);
+
+		// then
+		assertEquals(ReservationStatus.RESERVED, status);
+		System.out.println("status = " + status);
+	}
+
+	/**
+	 * 정해진 입실시간: starTime
+	 * 사용자의 입실시간: enterTime
+	 */
+	@Test
+	void 입실_시간에_맞게_출석() {
+		// given: 출석 시간이 아직 도래하지 않은 경우
+		LocalDateTime startTime = now;
+		Reservation reservation = ReservationTestHelper.createReservationWithEnterTime(startTime);
+		// when
+		ReservationStatus status = reservation.checkAttendanceStatus(startTime);
+
+		// then
+		assertEquals(ReservationStatus.ENTRANCE, status);
+		System.out.println("status = " + status);
+	}
+
+	/**
+	 * 정해진 입실시간: starTime
+	 * 사용자의 입실시간: enterTime
+	 */
+	@Test
+	void 입실_시간보다_30분_늦게_출석() {
+		// given: 출석 시간이 아직 도래하지 않은 경우
+		LocalDateTime startTime = now;
+		LocalDateTime enterTime = startTime.plusMinutes(30);
+		Reservation reservation = ReservationTestHelper.createReservationWithEnterTime(startTime);
+		// when
+		ReservationStatus status = reservation.checkAttendanceStatus(enterTime);
+
+		// then
+		assertEquals(ReservationStatus.ENTRANCE, status);
+		System.out.println("status = " + status);
+	}
+
+	/**
+	 * 정해진 입실시간: starTime
+	 * 사용자의 입실시간: enterTime
+	 */
+	@Test
+	void 입실시간_30분_초과_지각() {
+		// given: 출석 시간이 아직 도래하지 않은 경우
+		LocalDateTime startTime = now;
+		LocalDateTime enterTime = startTime.plusMinutes(31);
+		Reservation reservation = ReservationTestHelper.createReservationWithEnterTime(startTime);
+		// when
+		ReservationStatus status = reservation.checkAttendanceStatus(enterTime);
+
+		// then
+		assertEquals(ReservationStatus.LATE, status);
+		System.out.println("status = " + status);
+	}
+
+	/**
+	 * 정해진 입실시간: starTime
+	 * 사용자의 입실시간: enterTime
+	 */
+	@Test
+	void 입실시간_하루_이후_출석() {
+		// given: 출석 시간이 아직 도래하지 않은 경우
+		LocalDateTime startTime = now;
+		LocalDateTime enterTime = startTime.minusDays(1);
+		Reservation reservation = ReservationTestHelper.createReservationWithEnterTime(startTime);
+		// when
+		ReservationStatus status = reservation.checkAttendanceStatus(enterTime);
+
+		// then
+		assertEquals(ReservationStatus.RESERVED, status);
+		System.out.println("status = " + status);
+	}
+//
+// 	@Test
+// 	void getMyMostRecentReservation() {
+// 	}
+//
+// 	@Test
+// 	void getMyReservationQrCode() {
+// 	}
+//
+// 	@Test
+// 	void getSchedule() {
+// 	}
+//
+// 	@Test
+// 	void qrEntrance() {
+// 	}
+//
+// 	@Test
+// 	void createGroupReservation() {
+// 	}
+//
+// 	@Test
+// 	void cancelReservation() {
+// 	}
+}

--- a/backend/src/test/java/com/ice/studyroom/helper/ReservationTestHelper.java
+++ b/backend/src/test/java/com/ice/studyroom/helper/ReservationTestHelper.java
@@ -1,0 +1,30 @@
+package com.ice.studyroom.helper;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
+
+public class ReservationTestHelper {
+
+	public static Reservation createReservationWithEnterTime(LocalDateTime startDateTime) {
+		LocalTime startTime = startDateTime.toLocalTime();
+		return Reservation.builder()
+			.id(1L)
+			.firstScheduleId(100L)
+			.secondScheduleId(200L)
+			.userEmail("test@example.com")
+			.userName("테스트 유저")
+			.scheduleDate(LocalDate.now())
+			.roomNumber("A101")
+			.startTime(startTime)
+			.endTime(startTime.plusHours(2))
+			.enterTime(null) // 출석 시간 설정 가능
+			.status(ReservationStatus.RESERVED)
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.build();
+	}
+}


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 이제 프론트엔드에서 전달된 QR Code 이미지를 서버에서 처리하여 입실을 처리할 수 있습니다.
  - 출석 이전: 스터디룸 시작 시간 이전에 QR Code 사용 시 403 반환
  - 출석: 스터디룸 시작 시간부터 30분 이내 QR Code 사용 시 200과 ENTRANCE 반환
  - 지각: 스터디룸 시작 시간부터 30분 초과 스터디룸 종료 시간 이내 QR Code 사용 시 200과 LATE 반환
  - 만료: 스터디룸 시작 시간부터 종료 시간 초과 QR Code 사용 시 401 반환
- 프론트엔드에서 전송된 PNG를 BASE64로 디코딩 후 텍스트를 추출하는 과정에서 오류 발생
  - PNG를 BASE64로 변환하지않았던 오류 수정
- 레디스에 저장된 QR 데이터를 반환하는 과정에서 reservation의 고유 ID를 Long으로 변환하지 못하는 오류 수정
 

## 관련 이슈

- #31 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
### 출석 시간 이전에 입실 시도 시
![image](https://github.com/user-attachments/assets/0b2378a2-b1d4-46f5-ac09-a437a9085018)
### 정해진 정상 출석 시
![image](https://github.com/user-attachments/assets/18760f1f-066f-45a5-88f3-f61c2b0b962b)
### 지각 할 경우
![image](https://github.com/user-attachments/assets/e1f5a5b5-2ea6-4856-824c-77b6422daee7)
### 스터디룸 종료 시간 이후
![image](https://github.com/user-attachments/assets/08a9e107-16c2-4412-827d-4c629cf1fe73)


## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
