### PR TITLE
[BE-#127 #128 #129] Penalty 도메인 분류 및 노쇼 확인 스케줄러 생성

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
@@ -7,10 +7,10 @@ import com.ice.studyroom.domain.admin.presentation.dto.response.AdminDeleteOccup
 import com.ice.studyroom.domain.admin.presentation.dto.response.AdminPenaltyControlResponse;
 import com.ice.studyroom.domain.admin.presentation.dto.response.AdminPenaltyRecordResponse;
 import com.ice.studyroom.domain.membership.domain.entity.Member;
-import com.ice.studyroom.domain.membership.domain.entity.Penalty;
+import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
-import com.ice.studyroom.domain.membership.infrastructure.persistence.PenaltyRepository;
+import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
 import com.ice.studyroom.domain.admin.domain.entity.RoomTimeSlot;
 import com.ice.studyroom.domain.admin.domain.type.RoomTimeSlotStatus;
 import com.ice.studyroom.domain.admin.infrastructure.persistence.RoomTimeSlotRepository;

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/response/AdminPenaltyRecordResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/response/AdminPenaltyRecordResponse.java
@@ -2,7 +2,7 @@ package com.ice.studyroom.domain.admin.presentation.dto.response;
 
 import java.time.LocalDateTime;
 
-import com.ice.studyroom.domain.membership.domain.type.PenaltyReasonType;
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
 
 public record AdminPenaltyRecordResponse(
 	PenaltyReasonType reason,

--- a/backend/src/main/java/com/ice/studyroom/domain/identity/domain/application/EmailVerificationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/domain/application/EmailVerificationService.java
@@ -5,6 +5,7 @@ import java.security.SecureRandom;
 import org.springframework.stereotype.Service;
 
 import com.ice.studyroom.domain.identity.domain.service.VerificationCodeCacheService;
+import com.ice.studyroom.global.dto.request.EmailRequest;
 import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.service.EmailService;
 import com.ice.studyroom.global.type.StatusCode;
@@ -29,7 +30,7 @@ public class EmailVerificationService {
 		String body = buildVerificationEmailBody(authCode);
 		try {
 			resetTTL(email, authCode);
-			emailService.sendEmail(email, title, body);
+			emailService.sendEmail(new EmailRequest(email, title, body));
 		} catch (Exception e) {
 			log.error("인증 메일 전송 실패 {}: {}", email, e.getMessage());
 			throw new BusinessException(StatusCode.INTERNAL_ERROR, "인증 메일 전송 중 오류가 발생했습니다.");

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/type/PenaltyStatus.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/type/PenaltyStatus.java
@@ -1,6 +1,0 @@
-package com.ice.studyroom.domain.membership.domain.type;
-
-public enum PenaltyStatus {
-	VALID,
-	EXPIRED
-}

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/application/PenaltyService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/application/PenaltyService.java
@@ -1,10 +1,18 @@
 package com.ice.studyroom.domain.penalty.application;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 import org.springframework.stereotype.Service;
 
 import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.service.MemberDomainService;
+import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
 import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
 import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -15,5 +23,34 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PenaltyService {
 
+	private final PenaltyRepository penaltyRepository;
+	private final MemberDomainService memberDomainService;
 
+	@Transactional
+	public void assignPenalty(Member member, PenaltyReasonType reason){
+
+		Penalty penalty = Penalty.builder()
+			.member(member)
+			.reason(reason)
+			.penaltyEnd(calculatePenaltyEnd(reason.getDurationDays()))
+			.build();
+
+		member.updatePenalty(true);
+		penaltyRepository.save(penalty);
+	}
+
+	private LocalDateTime calculatePenaltyEnd(int durationDays) {
+		LocalDate penaltyEndDate = LocalDate.now().plusDays(durationDays); // 종료 날짜 계산
+		return LocalDateTime.of(penaltyEndDate, LocalTime.MAX); // 23:59:59
+	}
+
+	@Transactional
+	public void checkReservationNoShow(Reservation reservation, LocalDateTime now) {
+		if (reservation.checkAttendanceStatus(now) == ReservationStatus.NO_SHOW) {
+			Member member = memberDomainService.getMemberByEmail(reservation.getUserEmail());
+			assignPenalty(member, PenaltyReasonType.NO_SHOW);
+			log.info("해당 유저가 노쇼로 인해 7일 패널티가 부여되었습니다. 이름 : {} 학번 : {}", member.getName(), member.getStudentNum());
+		}
+		log.info("Processed no-show for reservation: {}", reservation.getId());
+	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/application/PenaltyService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/application/PenaltyService.java
@@ -1,0 +1,19 @@
+package com.ice.studyroom.domain.penalty.application;
+
+import org.springframework.stereotype.Service;
+
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
+import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PenaltyService {
+
+
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/entity/Penalty.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/entity/Penalty.java
@@ -1,9 +1,10 @@
-package com.ice.studyroom.domain.membership.domain.entity;
+package com.ice.studyroom.domain.penalty.domain.entity;
 
 import java.time.LocalDateTime;
 
-import com.ice.studyroom.domain.membership.domain.type.PenaltyStatus;
-import com.ice.studyroom.domain.membership.domain.type.PenaltyReasonType;
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyStatus;
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
 import com.ice.studyroom.global.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/type/PenaltyReasonType.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/type/PenaltyReasonType.java
@@ -1,4 +1,4 @@
-package com.ice.studyroom.domain.membership.domain.type;
+package com.ice.studyroom.domain.penalty.domain.type;
 
 public enum PenaltyReasonType {
 	CANCEL,

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/type/PenaltyReasonType.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/type/PenaltyReasonType.java
@@ -1,7 +1,14 @@
 package com.ice.studyroom.domain.penalty.domain.type;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum PenaltyReasonType {
-	CANCEL,
-	LATE,
-	NO_SHOW
+	CANCEL(2),
+	LATE(3),
+	NO_SHOW(7);
+
+	private final int durationDays;
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/type/PenaltyStatus.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/type/PenaltyStatus.java
@@ -1,0 +1,6 @@
+package com.ice.studyroom.domain.penalty.domain.type;
+
+public enum PenaltyStatus {
+	VALID,
+	EXPIRED
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/infrastructure/persistence/PenaltyRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/infrastructure/persistence/PenaltyRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 
 public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
 	Optional<Penalty> findTopByMemberIdAndPenaltyEndAfterOrderByPenaltyEndDesc(Long memberId, LocalDateTime currentTime);
+
 	List<Penalty> findByMemberIdAndPenaltyEndAfter(Long memberId, LocalDateTime currentTime);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/infrastructure/persistence/PenaltyRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/infrastructure/persistence/PenaltyRepository.java
@@ -1,6 +1,6 @@
-package com.ice.studyroom.domain.membership.infrastructure.persistence;
+package com.ice.studyroom.domain.penalty.infrastructure.persistence;
 
-import com.ice.studyroom.domain.membership.domain.entity.Penalty;
+import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
@@ -1,15 +1,25 @@
 package com.ice.studyroom.domain.penalty.scheduler;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.service.MemberDomainService;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
+import com.ice.studyroom.domain.penalty.application.PenaltyService;
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
 import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
 
 import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,6 +31,8 @@ public class PenaltyUpdateScheduler {
 
 	private final MemberRepository memberRepository;
 	private final PenaltyRepository penaltyRepository;
+	private final ReservationRepository reservationRepository;
+	private final PenaltyService penaltyService;
 
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *") // 매일 00:00에 실행
@@ -30,10 +42,21 @@ public class PenaltyUpdateScheduler {
 				.findTopByMemberIdAndPenaltyEndAfterOrderByPenaltyEndDesc(
 				member.getId(), LocalDateTime.now()).isPresent();
 
-
 			member.updatePenalty(hasPenalty);
 		});
 
-		log.info("Penalty counts updated successfully at {}", LocalDateTime.now());
+		log.info("Member Penalty updated successfully at {}", LocalDateTime.now());
+	}
+
+	@Scheduled(cron = "0 1 10-23,0 * * *") // 매일 10:01 ~ 23:01, 자정 00:01 실행
+	public void checkNoShowPenalty() {
+		LocalTime now = LocalTime.now().withSecond(0).withNano(0);
+
+		List<Reservation> expiredReservations = reservationRepository.findByEndTimeBetween(
+			now.minusMinutes(2), now);
+
+		expiredReservations.forEach(reservation -> {
+			penaltyService.checkReservationNoShow(reservation, LocalDateTime.from(now));
+		});
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
@@ -1,4 +1,4 @@
-package com.ice.studyroom.domain.membership.scheduler;
+package com.ice.studyroom.domain.penalty.scheduler;
 
 import java.time.LocalDateTime;
 
@@ -7,7 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
-import com.ice.studyroom.domain.membership.infrastructure.persistence.PenaltyRepository;
+import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -98,6 +98,7 @@ public class Reservation {
 			return ReservationStatus.LATE;
 			// 패널티 추가로직
 		} else {
+			markStatus(ReservationStatus.NO_SHOW);
 			return ReservationStatus.NO_SHOW;
 		}
 	}
@@ -109,8 +110,17 @@ public class Reservation {
 	}
 
 	public static Reservation from(List<Schedule> schedules, String email, String userName) {
+		if (schedules == null || schedules.isEmpty()) {
+			throw new IllegalArgumentException("Schedules List가 비어있습니다.");
+		}
+
 		Schedule firstSchedule = schedules.get(0);
 		Schedule secondSchedule = schedules.size() > 1 ? schedules.get(1) : null;
+
+		if (firstSchedule.getRoomNumber() == null) {
+			throw new IllegalArgumentException("firstSchedule은 null일  수 없습니다.");
+		}
+
 		return Reservation.builder()
 			.firstScheduleId(firstSchedule.getId())
 			.secondScheduleId(secondSchedule != null ? secondSchedule.getId() : null)

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
@@ -1,6 +1,7 @@
 package com.ice.studyroom.domain.reservation.infrastructure.persistence;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +15,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	List<Reservation> findByUserEmail(String email);
 
 	Optional<Reservation> findFirstByUserEmailOrderByCreatedAtDesc(String email);
+
+	List<Reservation> findByEndTimeBetween(LocalTime time1, LocalTime time2);
 }

--- a/backend/src/main/java/com/ice/studyroom/global/dto/request/EmailRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/global/dto/request/EmailRequest.java
@@ -1,0 +1,14 @@
+package com.ice.studyroom.global.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailRequest {
+	private String to;
+	private String subject;
+	private String body;
+}

--- a/backend/src/main/java/com/ice/studyroom/global/service/EmailService.java
+++ b/backend/src/main/java/com/ice/studyroom/global/service/EmailService.java
@@ -1,38 +1,7 @@
 package com.ice.studyroom.global.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.stereotype.Service;
+import com.ice.studyroom.global.dto.request.EmailRequest;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-
-@Service
-public class EmailService {
-
-	private static final Logger logger = LoggerFactory.getLogger(EmailService.class);
-	private final JavaMailSender mailSender;
-
-	public EmailService(JavaMailSender mailSender) {
-		this.mailSender = mailSender;
-	}
-
-	public void sendEmail(String to, String subject, String body) {
-		try {
-			MimeMessage mimeMessage = mailSender.createMimeMessage();
-			MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
-
-			helper.setTo(to);
-			helper.setSubject(subject);
-			helper.setText(body, true); // HTML 본문
-
-			mailSender.send(mimeMessage);
-			logger.info("알림 이메일 전송 성공: {}", to);
-		} catch (MessagingException e) {
-			logger.error("알림 이메일 전송 실패: {}", to, e);
-			throw new RuntimeException("메일 전송에 실패했습니다.", e);
-		}
-	}
+public interface EmailService {
+	void sendEmail(EmailRequest emailRequest);
 }

--- a/backend/src/main/java/com/ice/studyroom/global/service/GmailService.java
+++ b/backend/src/main/java/com/ice/studyroom/global/service/GmailService.java
@@ -1,0 +1,37 @@
+package com.ice.studyroom.global.service;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import com.ice.studyroom.global.dto.request.EmailRequest;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GmailService implements EmailService {
+
+	private final JavaMailSender mailSender;
+
+	public void sendEmail(EmailRequest emailRequest) {
+		try {
+			MimeMessage mimeMessage = mailSender.createMimeMessage();
+			MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+			helper.setTo(emailRequest.getTo());
+			helper.setSubject(emailRequest.getSubject());
+			helper.setText(emailRequest.getBody(), true); // HTML 본문
+
+			mailSender.send(mimeMessage);
+			log.info("알림 이메일 전송 성공: {}", emailRequest.getTo());
+		} catch (MessagingException e) {
+			log.error("알림 이메일 전송 실패: {}", emailRequest.getTo(), e);
+			throw new RuntimeException("메일 전송에 실패했습니다.", e);
+		}
+	}
+}

--- a/backend/src/test/java/com/ice/studyroom/domain/membership/infrastructure/email/EmailVerificationServiceTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/membership/infrastructure/email/EmailVerificationServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.ice.studyroom.domain.identity.domain.service.VerificationCodeCacheService;
 import com.ice.studyroom.domain.identity.domain.application.EmailVerificationService;
+import com.ice.studyroom.global.dto.request.EmailRequest;
 import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.service.CacheService;
 import com.ice.studyroom.global.service.EmailService;
@@ -39,14 +40,15 @@ class EmailVerificationServiceTest {
 	@DisplayName("이메일 전송이 성공했을 경우")
 	void testSendCodeToEmail() {
 		String email = "test@example.com";
+
 		when(cacheService.exists(email)).thenReturn(false); // Redis에 키가 없다고 가정
 		doNothing().when(cacheService).save(anyString(), anyString(), eq(Duration.ofMinutes(5)));
-		doNothing().when(emailService).sendEmail(anyString(), anyString(), anyString());
+		doNothing().when(emailService).sendEmail(any(EmailRequest.class));
 
 		emailVerificationService.sendCodeToEmail(email);
 		// Assert
 		verify(cacheService, times(1)).save(eq(email), anyString(), eq(Duration.ofMinutes(5)));
-		verify(emailService, times(1)).sendEmail(eq(email), anyString(), anyString());
+		verify(emailService, times(1)).sendEmail(any(EmailRequest.class));
 	}
 
 	@Test
@@ -61,7 +63,7 @@ class EmailVerificationServiceTest {
 
 		assertEquals("인증 메일이 이미 발송되었습니다.", exception.getMessage());
 		verify(cacheService, never()).save(anyString(), anyString(), eq(Duration.ofMinutes(5))); // save는 호출되지 않아야 함
-		verify(emailService, never()).sendEmail(anyString(), anyString(), anyString()); // 메일 발송도 호출되지 않아야 함
+		verify(emailService, never()).sendEmail(any(EmailRequest.class)); // 메일 발송도 호출되지 않아야 함
 	}
 
 	@Test

--- a/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
@@ -12,11 +12,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 
 import com.ice.studyroom.domain.membership.domain.entity.Member;
-import com.ice.studyroom.domain.membership.domain.entity.Penalty;
-import com.ice.studyroom.domain.membership.domain.type.PenaltyReasonType;
+import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
-import com.ice.studyroom.domain.membership.infrastructure.persistence.PenaltyRepository;
+import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
+import com.ice.studyroom.domain.penalty.scheduler.PenaltyUpdateScheduler;
 
 import jakarta.transaction.Transactional;
 

--- a/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/membership/scheduler/PenaltyUpdateSchedulerTest.java
@@ -2,7 +2,9 @@ package com.ice.studyroom.domain.membership.scheduler;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -11,13 +13,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
 import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.penalty.application.PenaltyService;
 import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
 import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
 import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
 import com.ice.studyroom.domain.penalty.scheduler.PenaltyUpdateScheduler;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
+import com.ice.studyroom.domain.reservation.domain.type.ScheduleStatus;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ScheduleRepository;
 
 import jakarta.transaction.Transactional;
 
@@ -34,6 +44,15 @@ class PenaltyUpdateSchedulerTest {
 
 	@Autowired
 	private PenaltyUpdateScheduler penaltyUpdateScheduler;
+
+	@Autowired
+	private ReservationRepository reservationRepository;
+
+	@Autowired
+	private ScheduleRepository scheduleRepository;
+
+	@Autowired
+	private PenaltyService penaltyService;
 
 	@Test
 	@DisplayName("패널티 스케줄러를 통해 Member의 패널티 여부가 갱신되어야한다.")
@@ -87,4 +106,72 @@ class PenaltyUpdateSchedulerTest {
 		assertThat(updatedMember1.isPenalty()).isTrue();
 		assertThat(updatedMember2.isPenalty()).isFalse();
 	}
+
+
+	@Test
+	@DisplayName("checkNoShowPenalty 메서드는 종료된 예약을 확인하고 노쇼 패널티를 부여해야 한다.")
+	void testCheckNoShowPenalty() {
+		// 1. 테스트 시간 설정
+		LocalTime now = LocalTime.of(11, 0).withSecond(0).withNano(0);
+
+		// 2. 테스트 데이터 생성 (스케줄)
+		Schedule schedule1 = Schedule.builder()
+			.scheduleDate(LocalDate.now())
+			.roomNumber("Room A")
+			.roomType(RoomType.GROUP)
+			.roomTimeSlotId(1L)
+			.startTime(LocalTime.of(10, 0))
+			.endTime(LocalTime.of(11, 0))
+			.capacity(10)
+			.currentRes(0)
+			.minRes(1)
+			.status(ScheduleStatus.AVAILABLE)
+			.build();
+
+		scheduleRepository.save(schedule1);
+
+		// 3. 테스트 데이터 생성 (멤버)
+		Member member1 = Member.builder()
+			.email(new Email("test1@hufs.ac.kr"))
+			.name("User1")
+			.password("password1")
+			.studentNum("12345")
+			.roles(List.of("ROLE_USER"))
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.isPenalty(false)
+			.build();
+
+		memberRepository.save(member1);
+
+		// 4. 테스트 데이터 생성 (예약)
+		Reservation reservation1 = Reservation.from(List.of(schedule1), member1.getEmail().getValue(), member1.getName());
+		reservationRepository.save(reservation1);
+
+
+		Reservation beforeUpdateReservation = reservationRepository.findById(reservation1.getId()).orElseThrow();
+		assertThat(beforeUpdateReservation.getStatus()).isEqualTo(ReservationStatus.RESERVED);
+
+		// 5. 스케줄러 실행
+		//penaltyUpdateScheduler.checkNoShowPenalty() 과 동일한 코드입니다.
+		List<Reservation> expiredReservations = reservationRepository.findByEndTimeBetween(
+			now.minusMinutes(2), now);
+		assertThat(expiredReservations.size()).isEqualTo(1);
+
+		// LocalDateTime 생성 시 LocalDate + LocalTime 사용
+		// 스케줄러와 동일한 시간에 맞추기 위해 +1 분에 예약 상태를 확인
+		expiredReservations.forEach(reservation -> {
+			penaltyService.checkReservationNoShow(reservation, LocalDateTime.of(LocalDate.now(), now.plusMinutes(1)));
+		});
+
+		// 6. 검증 - 예약 상태 확인
+		Reservation afterUpdateReservation = reservationRepository.findById(reservation1.getId()).orElseThrow();
+		assertThat(afterUpdateReservation.getStatus()).isEqualTo(ReservationStatus.NO_SHOW);
+
+		// 7. 검증 - 해당 예약을 한 member의 패널티 확인
+		List<Penalty> penalties = penaltyRepository.findAll();
+		assertThat(penalties.get(0).getMember().getId()).isEqualTo(member1.getId());
+		assertThat(penalties.get(0).getReason()).isEqualTo(PenaltyReasonType.NO_SHOW);
+	}
+
 }

--- a/backend/src/test/java/com/ice/studyroom/domain/penalty/application/PenaltyServiceTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/penalty/application/PenaltyServiceTest.java
@@ -1,0 +1,76 @@
+package com.ice.studyroom.domain.penalty.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.vo.Email;
+import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
+import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
+import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@Transactional
+@Rollback
+@DisplayName("PenaltyService 테스트")
+class PenaltyServiceTest {
+
+	@Autowired
+	private PenaltyService penaltyService;
+
+	@Autowired
+	private PenaltyRepository penaltyRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("assignPenalty 메서드는 멤버에게 패널티를 부여하고 저장해야 한다.")
+	void testAssignPenalty() {
+
+		// 1. 테스트 데이터 생성 (멤버)
+		Member member = Member.builder()
+			.email(new Email("test1@hufs.ac.kr"))
+			.name("User1")
+			.password("password1")
+			.studentNum("12345")
+			.roles(List.of("ROLE_USER"))
+			.createdAt(LocalDateTime.now())
+			.updatedAt(LocalDateTime.now())
+			.isPenalty(false)
+			.build();
+
+		memberRepository.save(member);
+
+		// 2. 패널티 부여
+		penaltyService.assignPenalty(member, PenaltyReasonType.NO_SHOW);
+
+		// 3. 검증 - 멤버 상태 업데이트
+		Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+		assertThat(updatedMember.isPenalty()).isTrue();
+
+		// 4. 검증 - 패널티 저장 여부
+		List<Penalty> penalties = penaltyRepository.findAll();
+		assertThat(penalties.size()).isEqualTo(1);
+
+		Penalty penalty = penalties.get(0);
+		assertThat(penalty.getMember().getId()).isEqualTo(member.getId());
+		assertThat(penalty.getReason()).isEqualTo(PenaltyReasonType.NO_SHOW);
+
+		// 5. 검증 - penaltyEnd 값
+		LocalDateTime expectedEndDate = LocalDateTime.now().plusDays(PenaltyReasonType.NO_SHOW.getDurationDays());
+		assertThat(penalty.getPenaltyEnd().toLocalDate()).isEqualTo(expectedEndDate.toLocalDate());
+	}
+}


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 이메일 발송 로직 추상화
- 패널티 계층 분리
- 패널티 유형 시간 정리
- 노쇼 패널티 스케줄러 제작

## 관련 이슈

#127 #128 #129 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 작업 정리
### 1. 패널티 계층 분리

현재 Penalty는 `membership`(회원), `reservation`(예약), `admin`(관리자) 도메인들과 밀접하게 연관됩니다.

Penalty 계층을 membership 내에 생성해두었는데, 여러 도메인에서 사용되는 것을 감안하여 독립적인 도메인으로 봐야한다고 판단하여 이를 분리하는 작업을 진행했습니다.

### 2. 패널티 유형 시간 정리

```java
@Getter
@RequiredArgsConstructor
public enum PenaltyReasonType {
	CANCEL(2),
	LATE(3),
	NO_SHOW(7);

	private final int durationDays;
}
```

취소(1시간 전) | 2일
-- | --
지각 | 3일
노쇼 | 7일


<!-- notionvc: 2da2c9b8-4211-460f-acd7-551ebb0d3ca9 -->

예 ) `1.1 13:30`에 지각 패널티가 부여될 경우 

- `1.4 23:59` 까지는 패널티 상태,
- `1.5 00:00` 에 스케줄러를 통해 패널티 해제

주말 여부는 따로 반영하지 않았습니다.

### 3. 노쇼 패널티 스케줄러 제작

```java
@Scheduled(cron = "0 1 10-23,0 * * *") // 매일 10:01 ~ 23:01, 자정 00:01 실행
	public void checkNoShowPenalty() {
		LocalTime now = LocalTime.now().withSecond(0).withNano(0);

		List<Reservation> expiredReservations = reservationRepository.findByEndTimeBetween(
			now.minusMinutes(2), now);

		expiredReservations.forEach(reservation -> {
			penaltyService.checkReservationNoShow(reservation, LocalDateTime.from(now));
		});
	}
```

- 매일 10:01 ~ 00:01 에 실행되는
- 스케줄러가 동작하는 시점을 기준으로 끝나는 예약들을 찾아 노쇼 여부를 확인합니다.


### 추가 내용
패널티 관련 로직은 해당 계층에 모아두는 리팩토링을 차차 진행해볼 예정입니다.

현재 패널티에 대한 접근이 다양한 부분에서 혼재되어있는데 한곳으로 통일해보면 좋을 것 같습니다!
