### PR TITLE
[BE-#136] 현재 시각 이전 스케줄에 대해서는 예약 불가 추가

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -329,8 +329,15 @@ public class ReservationService {
 	}
 
 	private void validateSchedulesAvailable(List<Schedule> schedules) {
-		if (schedules.stream().anyMatch(schedule -> !schedule.isAvailable() || !schedule.isCurrentResLessThanCapacity())) {
-			throw new IllegalStateException(("예약이 불가능합니다."));
+		LocalDateTime now = LocalDateTime.now();
+
+		if (schedules.stream().anyMatch(schedule -> {
+			LocalDateTime scheduleStartDateTime = LocalDateTime.of(schedule.getScheduleDate(), schedule.getStartTime());
+			return !schedule.isAvailable() ||
+				!schedule.isCurrentResLessThanCapacity() ||
+				scheduleStartDateTime.isBefore(now); // 현재 시간보다 이전이면 예외 발생
+		})) {
+			throw new IllegalStateException("예약이 불가능합니다.");
 		}
 	}
 }


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [ ] 새로운 기능
- [x] 리팩토링
- [x] 문서 수정
- [ ] 기타

## 변경 사항

1. 현재 시각 이전 스케줄에 대해서 예약 불가 기능 추가
-> validateSchedulesAvailable 메서드 수정

## 관련 이슈

(#136)

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷

<img width="902" alt="image" src="https://github.com/user-attachments/assets/396dfaa7-35ef-4502-8133-973d2bddf40b" />
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/d9a513aa-a1cd-4e6d-9a27-814a4c0a5c71" />
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/2315513d-53e0-465b-bd73-4aeeb7fbfb6c" />
현재시각 이후의 스케줄에 대해서는 예약이 가능하지만
이전스케줄에 대해서는 예외처리 완료 
-> 현재 모든 예외처리에 대한 이유반환은 되어있지 않습니다.
또한 개인예약/단체예약 전용방에 대한 예약설정을 해놓아 개인예약 테스트시 방예약 상태를 바꿔줘야 합니다.


## 기타

@glaxyt 님이 스케줄 검사에 대한 메서드를 따로 분리해주셔서 수정이 쉬웠습니다.
