### PR TITLE
[BE-#151] 내 예약 조회 api 참여자 정보 반영

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/ReservationController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/ReservationController.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,13 +16,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ice.studyroom.domain.reservation.application.ReservationService;
-import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
 import com.ice.studyroom.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import com.ice.studyroom.domain.reservation.presentation.dto.response.CancelReservationResponse;
 import com.ice.studyroom.domain.reservation.presentation.dto.response.GetMostRecentReservationResponse;
+import com.ice.studyroom.domain.reservation.presentation.dto.response.GetReservationsResponse;
 import com.ice.studyroom.global.dto.response.ResponseDto;
-import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.type.StatusCode;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,17 +47,16 @@ public class ReservationController {
 	 * @return List 형태의 내 예약 정보들
 	 * exception handler 전역 처리로 수정 예정
 	 */
-	//@ExceptionHandler(BusinessException.class)
 	@Operation(summary = "내 예약 정보 조회", description = "현재 사용자의 예약 정보를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "예약 정보 조회 성공")
 	@ApiResponse(responseCode = "500", description = "예약 정보 조회 실패")
 	@GetMapping("/reservations/my")
-	public ResponseEntity<ResponseDto<List<Reservation>>> getMyReservation(
+	public ResponseEntity<ResponseDto<List<GetReservationsResponse>>> getMyReservation(
 		@RequestHeader("Authorization") String authorizationHeader
 	) {
 		return ResponseEntity
 			.status(StatusCode.OK.getStatus())
-			.body(ResponseDto.of(reservationService.getMyAllReservation(authorizationHeader)));
+			.body(ResponseDto.of(reservationService.getReservations(authorizationHeader)));
 	}
 
 	@GetMapping("/reservations/my/latest")

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetReservationsResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetReservationsResponse.java
@@ -1,0 +1,33 @@
+package com.ice.studyroom.domain.reservation.presentation.dto.response;
+
+import java.util.List;
+
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public record GetReservationsResponse(
+	Reservation reservation,
+	List<Participant> participants
+) {
+	public static GetReservationsResponse from(Reservation reservation, List<Participant> participants) {
+		return new GetReservationsResponse(reservation, participants);
+	}
+
+	@Getter
+	@Builder
+	public static class Participant {
+		private String studentNum;
+		private String name;
+
+		public static Participant from(Member member) {
+			return Participant.builder()
+				.studentNum(member.getStudentNum())
+				.name(member.getName())
+				.build();
+		}
+	}
+
+}


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 내 예약 조회 api 응답에 참여자 정보를 추가했습니다.

## 관련 이슈

#151 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷

기존 응답에서 예약별로 참여자 배열인  participants 배열을 추가했습니다.
<img width="488" alt="image" src="https://github.com/user-attachments/assets/01d37766-f07e-4c74-aff1-a8dc4824f12e" />
<img width="484" alt="image" src="https://github.com/user-attachments/assets/e5c4410b-b625-4d8e-810c-116a924d23f0" />


## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
