### PR TITLE
[BE-#171] 로그인 시 사용자 권한 반환

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/identity/domain/JwtToken.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/domain/JwtToken.java
@@ -11,4 +11,5 @@ public class JwtToken {
 	private String grantType;
 	private String accessToken;
 	private String refreshToken;
+	private String role;
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/JwtTokenProvider.java
@@ -46,6 +46,7 @@ public class JwtTokenProvider {
 		// 권한 가져오기
 		String authorities = authentication.getAuthorities().stream()
 			.map(GrantedAuthority::getAuthority)
+			.map(role -> role.startsWith("ROLE_") ? role : "ROLE_" + role)
 			.collect(Collectors.joining(","));
 
 		long now = (new Date()).getTime();
@@ -66,6 +67,7 @@ public class JwtTokenProvider {
 			.grantType("Bearer")
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)
+			.role(authorities)
 			.build();
 	}
 
@@ -80,7 +82,7 @@ public class JwtTokenProvider {
 
 		// 클레임에서 권한 정보 가져오기
 		Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
-			.map(SimpleGrantedAuthority::new)
+			.map(role -> new SimpleGrantedAuthority(role.startsWith("ROLE_") ? role : "ROLE_" + role))
 			.collect(Collectors.toList());
 
 		// UserDetails 객체를 만들어서 Authentication return

--- a/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/infrastructure/security/SecurityConfig.java
@@ -34,14 +34,22 @@ public class SecurityConfig {
 			.sessionManagement(sessionManagement ->
 				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(authorize -> authorize
+				// 일반 API - 로그인한 사용자만 접근 가능
 				.requestMatchers(
-					"/api/reservations/**",
-					"/api/**", // API 개발을 위한 임시 사용
-					"/api/schedules/**",
+					"/api/**",
 					"/api/users/**",
-					"/api/email/**",  // 이메일 전송 API 경로
-					"/api/admin/**"   // 관리자 예약 API 경로
+					"/api/qr/**", // API 개발을 위한 임시 사용
+					"/api/schedules/**",
+					"/api/reservations/**"
 				).permitAll()
+
+				// TODO: 관리자 기능 완성 이후 주석 처리된 코드 활성화 예정
+				// .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
+				// .requestMatchers(
+				// 	"/api/reservations/**"
+				// 	).authenticated()
+
 				// Swagger 관련 경로 허용
 				.requestMatchers(
 					"/swagger-ui.html",

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/request/MemberLoginRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/request/MemberLoginRequest.java
@@ -1,17 +1,15 @@
 package com.ice.studyroom.domain.membership.presentation.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record MemberLoginRequest(
 	@NotBlank(message = "이메일은 필수입니다.")
-	@Schema(description = "아이디", example = "glaxyt@naver.com", required = true)
+	@Schema(description = "아이디", example = "glaxyt@naver.com")
 	@Email(message = "올바른 이메일 형식이 아닙니다.")
 	String email,
-	@Schema(description = "비밀번호", example = "p1a2s3s4Word", required = true)
+	@Schema(description = "비밀번호", example = "p1a2s3s4Word")
 	@NotBlank(message = "비밀번호는 필수입니다.")
 	String password
 ) {

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberLoginResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberLoginResponse.java
@@ -2,15 +2,27 @@ package com.ice.studyroom.domain.membership.presentation.dto.response;
 
 import com.ice.studyroom.domain.identity.domain.JwtToken;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
 public record MemberLoginResponse(
+	@NotNull
+	@Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnbGF4eXRAaHVmcy5hYy5rciIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE3MzkyODc0MDR9.krKvoSNZBx3r7hrrym-WKslbQclORPwbkDEeWJeHMpw")
 	String accessToken,
-	String refreshToken
+	@NotNull
+	@Schema(description = "Refresh Token", example = "2eff31c6-dc7e-4f07-b1f9-6cdd4ab97a83")
+	String refreshToken,
+
+	@NotNull
+	@Schema(description = "사용자 권한", example = "ROLE_USER")
+	String role
 ) {
-	// factory 메서드를 통한 생성
+
 	public static MemberLoginResponse of(JwtToken jwtToken) {
 		return new MemberLoginResponse(
 			jwtToken.getAccessToken(),
-			jwtToken.getRefreshToken()
+			jwtToken.getRefreshToken(),
+			jwtToken.getRole()
 		);
 	}
 }


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 로그인 시 사용자 권한을 반환하기에 권한에 따른 라우팅이 가능합니다.
- Security Config에 일반 사용자나 비회원이 관리자 API에 접근할 수 없게 구현했습니다.
  - 다만 현재 주석 처리를 했으니 프론트엔드가 구현을 마무리하면 활성화 할 예정입니다. 

## 관련 이슈

- #171 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
### 일반 사용자일 경우: ROLE_USER
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/5b10d901-59bc-4837-99c1-a7bdb4cc3a9d" />  

### 관리자일 경우: ROLE_ADMIN
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/4369314a-b002-4760-a193-e842823642fa" />  

### 일반 사용자가 ADMIN API를 호출할 경우
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/7ee01b8c-4332-4562-90cf-dfb5aaa9221e" />

## 기타

SecurityConfig에서 제가 놓친 부분이 있는지 확인해주세요.  
나중에 재구성은 해야할 것 같습니다. 같이 해봐요