### PR TITLE
[BE-#192] RT를 헤더를 통해서 전달하도록 수정

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
@@ -13,12 +13,10 @@ import com.ice.studyroom.domain.identity.infrastructure.security.JwtTokenProvide
 import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.membership.domain.service.MemberDomainService;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
-import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
 import com.ice.studyroom.domain.membership.presentation.dto.request.EmailVerificationRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberCreateRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberEmailVerificationRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberLoginRequest;
-import com.ice.studyroom.domain.membership.presentation.dto.request.TokenRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.UpdatePasswordRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.response.MemberEmailResponse;
 import com.ice.studyroom.domain.membership.presentation.dto.response.MemberLoginResponse;
@@ -42,7 +40,7 @@ public class MembershipService {
 		return MemberResponse.of("success");
 	}
 
-	public MemberLoginResponse login(MemberLoginRequest request) {
+	public JwtToken login(MemberLoginRequest request) {
 		Authentication authentication = authenticationManager.authenticate(
 			new UsernamePasswordAuthenticationToken(request.email(), request.password())
 		);
@@ -50,23 +48,23 @@ public class MembershipService {
 		JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 		tokenService.saveRefreshToken(request.email(), jwtToken.getRefreshToken());
 
-		return MemberLoginResponse.of(jwtToken);
+		return jwtToken;
 	}
 
-	public MemberLoginResponse refresh(String authorizationHeader, TokenRequest request) {
+	public JwtToken refresh(String authorizationHeader, String refreshToken) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
 
-		JwtToken jwtToken = tokenService.rotateToken(email, request.refreshToken());
+		JwtToken jwtToken = tokenService.rotateToken(email, refreshToken);
 
-		return MemberLoginResponse.of(jwtToken);
+		return jwtToken;
 	}
 
-	public MemberResponse logout(String authorizationHeader, TokenRequest request) {
+	public MemberResponse logout(String authorizationHeader, String refreshToken) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
 
-		tokenService.deleteToken(email, request.refreshToken());
+		tokenService.deleteToken(email, refreshToken);
 
-		return MemberResponse.of("success");
+		return MemberResponse.of("정상적으로 로그아웃 되었습니다.");
 	}
 
 	public String updatePassword(String authorizationHeader, UpdatePasswordRequest request) {

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/request/TokenRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/request/TokenRequest.java
@@ -1,9 +1,0 @@
-package com.ice.studyroom.domain.membership.presentation.dto.request;
-
-import jakarta.validation.constraints.NotNull;
-
-public record TokenRequest(
-	@NotNull(message = "Refresh Token은 필수입니다.")
-	String refreshToken
-) {
-}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberLoginResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberLoginResponse.java
@@ -10,10 +10,6 @@ public record MemberLoginResponse(
 	@Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnbGF4eXRAaHVmcy5hYy5rciIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE3MzkyODc0MDR9.krKvoSNZBx3r7hrrym-WKslbQclORPwbkDEeWJeHMpw")
 	String accessToken,
 	@NotNull
-	@Schema(description = "Refresh Token", example = "2eff31c6-dc7e-4f07-b1f9-6cdd4ab97a83")
-	String refreshToken,
-
-	@NotNull
 	@Schema(description = "사용자 권한", example = "ROLE_USER")
 	String role
 ) {
@@ -21,7 +17,6 @@ public record MemberLoginResponse(
 	public static MemberLoginResponse of(JwtToken jwtToken) {
 		return new MemberLoginResponse(
 			jwtToken.getAccessToken(),
-			jwtToken.getRefreshToken(),
 			jwtToken.getRole()
 		);
 	}


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- RT를 HTTP secure 헤더를 통한 저장 및 Refresh API 호출 시 헤더로 전달 받게 수정
- HttpOnly 와 Secure Cookie를 활용하기
- 전달 받는 HTTP는 Cookie에 저장됩니다. 
  - 예시: Set-Cookie: refresh_token=485e9a21-8d03-44b7-b4ce-e19551963aec; Path=/auth/refresh; Max-Age=604800; Expires=Wed, 19 Feb 2025 16:06:25 GMT; HttpOnly; SameSite=Strict
 

## 관련 이슈

- #192 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷

필요한 경우 스크린샷을 첨부해주세요.

## 기타

확인해보시고 문의 사항 주세요:)
