### PR TITLE
[BE-#194] 유저 정보 조회 응답 데이터, 패널티 데이터 추가

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
@@ -16,7 +16,6 @@ import com.ice.studyroom.domain.identity.infrastructure.security.JwtTokenProvide
 import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.membership.domain.service.MemberDomainService;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
-import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
 import com.ice.studyroom.domain.membership.presentation.dto.request.EmailVerificationRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberCreateRequest;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberEmailVerificationRequest;
@@ -29,8 +28,6 @@ import com.ice.studyroom.domain.membership.presentation.dto.response.MemberLooku
 import com.ice.studyroom.domain.membership.presentation.dto.response.MemberResponse;
 import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
 import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
-import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
-import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,7 +40,6 @@ public class MembershipService {
 	private final TokenService tokenService;
 	private final AuthenticationManager authenticationManager;
 	private final EmailVerificationService emailVerificationService;
-	private final ReservationRepository reservationRepository;
 	private final PenaltyRepository penaltyRepository;
 
 	public MemberResponse createMember(MemberCreateRequest request) {

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberLookupResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/presentation/dto/response/MemberLookupResponse.java
@@ -1,10 +1,22 @@
 package com.ice.studyroom.domain.membership.presentation.dto.response;
 
+import java.time.LocalDateTime;
+
+import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
+
 public record MemberLookupResponse(
 	String email,
-	String name
+	String name,
+	PenaltyReasonType penaltyReasonType,
+	LocalDateTime penaltyEndAt
 ) {
-	public static MemberLookupResponse of(String email, String name){
-		return new MemberLookupResponse(email, name);
+	public static MemberLookupResponse of(String email, String name, PenaltyReasonType penaltyReasonType,
+		LocalDateTime penaltyEndAt) {
+
+		return new MemberLookupResponse(email, name, penaltyReasonType, penaltyEndAt);
+	}
+
+	public static MemberLookupResponse of(String email, String userName) {
+		return new MemberLookupResponse(email, userName, null, null);
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/entity/Penalty.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/entity/Penalty.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.penalty.domain.type.PenaltyStatus;
 import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import com.ice.studyroom.global.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -18,6 +19,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -41,6 +43,10 @@ public class Penalty extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reservation_id", nullable = false, unique = true)
+	private Reservation reservation;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/entity/Penalty.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/entity/Penalty.java
@@ -63,4 +63,8 @@ public class Penalty extends BaseTimeEntity {
 	@Column(name = "status", nullable = false)
 	@Builder.Default
 	private PenaltyStatus status = PenaltyStatus.VALID;
+
+	public boolean isExpired() {
+		return LocalDateTime.now().isAfter(penaltyEnd);
+	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -132,7 +132,7 @@ public class ReservationService {
 			throw new AttendanceException("출석 시간이 만료되었습니다.", HttpStatus.GONE);
 		} else if(status == ReservationStatus.LATE){
 			//해당 멤버에게 패널티 부여
-			penaltyService.assignPenalty(memberRepository.getMemberByEmail(Email.of(memberEmail)), PenaltyReasonType.LATE);
+			penaltyService.assignPenalty(memberRepository.getMemberByEmail(Email.of(memberEmail)), reservationId, PenaltyReasonType.LATE);
 		}
 		return status;
 	}
@@ -192,7 +192,6 @@ public class ReservationService {
 		// 예약 가능 여부 확인
 		List<Schedule> schedules = findSchedules(request.scheduleId());
 		validateSchedulesAvailable(schedules);
-
 
 		// 스케줄에서 Type을 저장해야하며, Type에 따른 RES 처리가 필요하다.
 		RoomType roomType = schedules.get(0).getRoomType();
@@ -309,7 +308,7 @@ public class ReservationService {
 
 		if (!now.isBefore(startTime.minus(1, ChronoUnit.HOURS))) {
 			// 취소 패널티 부여
-			penaltyService.assignPenalty(memberRepository.getMemberByEmail(Email.of(email)), PenaltyReasonType.CANCEL);
+			penaltyService.assignPenalty(memberRepository.getMemberByEmail(Email.of(email)), id, PenaltyReasonType.CANCEL);
 		}
 
 		/*
@@ -324,7 +323,7 @@ public class ReservationService {
 			scheduleRepository.findById(reservation.getSecondScheduleId()).ifPresent(Schedule::cancel);
 		}
 
-		reservationRepository.delete(reservation);
+		reservation.cancelReservation();
 		return new CancelReservationResponse(id);
 	}
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -101,7 +101,6 @@ public class Reservation {
 		} else if (minutesDifference <= minutesDurationOfReservation) {
 			markStatus(ReservationStatus.LATE);
 			return ReservationStatus.LATE;
-			// 패널티 추가로직
 		} else {
 			markStatus(ReservationStatus.NO_SHOW);
 			return ReservationStatus.NO_SHOW;
@@ -117,6 +116,11 @@ public class Reservation {
 	public void extendReservation(Long secondScheduleId, LocalTime endTime) {
 		this.secondScheduleId = secondScheduleId;
 		this.endTime = endTime;
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public void cancelReservation() {
+		this.status = ReservationStatus.CANCELLED;
 		this.updatedAt = LocalDateTime.now();
 	}
 

--- a/backend/src/test/java/com/ice/studyroom/domain/penalty/application/PenaltyServiceTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/penalty/application/PenaltyServiceTest.java
@@ -55,7 +55,7 @@ class PenaltyServiceTest {
 		memberRepository.save(member);
 
 		// 2. 패널티 부여
-		penaltyService.assignPenalty(member, PenaltyReasonType.NO_SHOW);
+		penaltyService.assignPenalty(member, 1L, PenaltyReasonType.NO_SHOW);
 
 		// 3. 검증 - 멤버 상태 업데이트
 		Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- penalty 테이블에 reservation의 id 를 외래키로 추가
- 유저 정보 조회의 응답 데이터에 패널티 사유, 패널티 종료 기간을 추가해두었습니다.

## 관련 이슈

#194 #

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷

![image](https://github.com/user-attachments/assets/fb9ae6e3-bce4-454c-9893-bb6d07d53005)

## 기타

현재 패널티 이유는 영어로, 패널티 종료 시간은 별로도 파싱을 진행하지 않았습니다. 
프론트 측에서 약간의 변형이 필요합니다.
