### PR TITLE
[FE-#262] 연장 및 취소 페이지 예약자 오류 및 안내 문구 수정

### DIFF
--- a/frontend/src/pages/Reservation/StudyRoomManage.jsx
+++ b/frontend/src/pages/Reservation/StudyRoomManage.jsx
@@ -110,6 +110,10 @@ const StudyRoomManage = () => {
     if (!booking.endTime) return [];
   
     const [endHour, endMinute] = booking.endTime.split(':').map(Number);
+
+    if (endHour === 22 && endMinute === 0) {
+      return [];
+    }
   
     // 연장 시간 (종료 시간 +1시간)
     const extendedHour = endHour + 1;
@@ -317,7 +321,8 @@ const StudyRoomManage = () => {
               <div>
                 <div className="text-sm text-gray-600 mb-1">예약자</div>
                 <div className="flex items-center gap-1">
-                  <span className="font-medium text-gray-900">{booking.userName}</span>
+                  <span className="font-medium text-gray-900">{booking.participants[0].name}</span>
+                  <span className="text-sm text-gray-500">({booking.participants[0].studentNum})</span>
                 </div>
               </div>
               

--- a/frontend/src/pages/Reservation/StudyRoomManage.jsx
+++ b/frontend/src/pages/Reservation/StudyRoomManage.jsx
@@ -444,7 +444,8 @@ const StudyRoomManage = () => {
                   <div>
                     <div className="text-sm text-gray-600 mb-1">예약자</div>
                   <div className="flex items-center gap-1">
-                    <span className="font-medium text-gray-900">{booking.userName}</span>
+                    <span className="font-medium text-gray-900">{booking.participants[0].name}</span>
+                    <span className="text-sm text-gray-500">({booking.participants[0].studentNum})</span>
                   </div>
                   </div>
 
@@ -473,9 +474,9 @@ const StudyRoomManage = () => {
               <span className="font-semibold text-slate-900">연장 안내</span>
             </div>
             <p className="text-sm text-gray-600">
-              연장은 예약 종료 10분 전부터 가능합니다.
-              <br />
-              (현재 예약: {booking.endTime} 종료 → {booking.extendDeadline}부터 연장 가능)
+              연장은 사용 종료 10분 전부터 가능합니다.
+              {/* <br />
+              (현재 예약: {booking.endTime} 종료 → {booking.extendDeadline}부터 연장 가능)  임시로 삭제*/}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 연장 및 취소 페이지의 예약자명을 제대로 호출하고 안내 문구 예시를 삭제하였다.

## 관련 이슈

- #262 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷

![image](https://github.com/user-attachments/assets/4fe342c2-1f38-42a9-a05e-850a9bd3b99d)
