### PR TITLE
[BE-#300] 개인예약의 경우 개인 정보만 반환

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetReservationsResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetReservationsResponse.java
@@ -1,33 +1,11 @@
 package com.ice.studyroom.domain.reservation.presentation.dto.response;
 
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import java.util.List;
 
-import com.ice.studyroom.domain.membership.domain.entity.Member;
-import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
-
-import lombok.Builder;
-import lombok.Getter;
-
-public record GetReservationsResponse(
-	Reservation reservation,
-	List<Participant> participants
-) {
-	public static GetReservationsResponse from(Reservation reservation, List<Participant> participants) {
+public record GetReservationsResponse(Reservation reservation, List<ParticipantResponse> participants) {
+	public static GetReservationsResponse from(Reservation reservation, List<ParticipantResponse> participants) {
 		return new GetReservationsResponse(reservation, participants);
 	}
-
-	@Getter
-	@Builder
-	public static class Participant {
-		private String studentNum;
-		private String name;
-
-		public static Participant from(Member member) {
-			return Participant.builder()
-				.studentNum(member.getStudentNum())
-				.name(member.getName())
-				.build();
-		}
-	}
-
 }
+

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/ParticipantResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/ParticipantResponse.java
@@ -1,0 +1,10 @@
+package com.ice.studyroom.domain.reservation.presentation.dto.response;
+
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+
+public record ParticipantResponse(String studentNum, String name) {
+	public static ParticipantResponse from(Member member) {
+		return new ParticipantResponse(member.getStudentNum(), member.getName());
+	}
+}
+


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능
- [x] 리팩토링

## 변경 사항
- 개인 예약의 경우 본인의 정보만 확인하게 수정
```
public class ReservationService {
	public List<GetReservationsResponse> getReservations(String authorizationHeader) {
                  // 코드 생략

		// 최근 예약 가져오기
		Optional<Reservation> recentReservation = reservationRepository.findFirstByUserEmailOrderByCreatedAtDesc(email);

		// 최근 예약에서 scheduleId 추출 후 Schedule 조회
		Schedule schedule = recentReservation
			.map(Reservation::getFirstScheduleId) // scheduleId 가져오기
			.flatMap(scheduleRepository::findById) // scheduleId로 조회
			.orElseThrow(() -> new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄입니다."));

		if (schedule.getRoomType().equals(RoomType.INDIVIDUAL)) {
			return recentReservation
				.map(reservation -> List.of(GetReservationsResponse.from(reservation, List.of()))) // 빈 리스트 반환
				.orElseThrow(() -> new BusinessException(StatusCode.NOT_FOUND, "최근 예약을 찾을 수 없습니다."));
		}
```
해당 스케줄이 개인예약인지 그룹 예약인지 확인 후  
개인 예약의 경우 본인의 정보만 반환하게 수정  

```
public record GetReservationsResponse(Reservation reservation, List<ParticipantResponse> participants) {
	public static GetReservationsResponse from(Reservation reservation, List<ParticipantResponse> participants) {
		return new GetReservationsResponse(reservation, participants);
	}
}
```
코드의 가독성을 위해 Record로 변환  
조건: 서비스 로직에서 불변성을 유지하는 비즈니스 로직만 작성되어있을 것  
위의 조건을 만족하기에 응답 DTO Record로 수정  

## 관련 이슈

- #300 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/4c06dcca-ce67-4844-96ea-82168ed189c5" />

<img width="1178" alt="image" src="https://github.com/user-attachments/assets/76ef7482-e4ef-405b-b039-ef4b0f0273c2" />


## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
