### PR TITLE
[BE-#308] 개인, 단체 예약 정보 모두 반환하게 수정

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetReservationsResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetReservationsResponse.java
@@ -1,7 +1,8 @@
 package com.ice.studyroom.domain.reservation.presentation.dto.response;
 
-import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import java.util.List;
+
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 
 public record GetReservationsResponse(Reservation reservation, List<ParticipantResponse> participants) {
 	public static GetReservationsResponse from(Reservation reservation, List<ParticipantResponse> participants) {


### PR DESCRIPTION
## PR 종류

- [x] 리팩토링

## 변경 사항
- 가장 최근의 예약 정보만 받아오는 에러 발생
- 예약 정보가 없는 경우 에러 발생
```
Schedule schedule = scheduleRepository.findById(reservation.getFirstScheduleId())
	.orElseThrow(() -> new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄입니다."));
if (schedule.getRoomType() == RoomType.GROUP) {
```
위 코드를 추가하여 Group 예약의 경우에만 참여자 정보를 담게 수정
## 관련 이슈

- #308 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷


## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
