### PR TITLE
[FE-#341] 토큰 재발급 함수 catch문으로 이동

### DIFF
--- a/frontend/src/pages/Mainpage/handlers/MainpageHandlers.jsx
+++ b/frontend/src/pages/Mainpage/handlers/MainpageHandlers.jsx
@@ -20,7 +20,7 @@ export const useMainpageHandlers = () => {
     const [showPenaltyPopup, setShowPenaltyPopup] = useState(false);
     const [showQRModal, setShowQRModal] = useState(false);
     const { addNotification } = useNotification();
-    const accessToken = sessionStorage.getItem('accessToken');
+    let accessToken = sessionStorage.getItem('accessToken');
 
     useEffect(() => {
       const fetchUserData = async () => {
@@ -31,22 +31,9 @@ export const useMainpageHandlers = () => {
                   return;
               }
   
-              const response = await axios.get('/api/users', {
+              let response = await axios.get('/api/users', {
                   headers: { Authorization: `Bearer ${accessToken}` }
               });
-  
-              if (response.status === 401) {
-                console.warn('토큰이 만료됨. 새로고침 시도.');
-  
-                  accessToken = await refreshTokens();
-                  if (accessToken) {
-                      return fetchUserData();
-                  } else {
-                    console.error('토큰 갱신 실패. 로그아웃 필요.');
-                      return;
-                  }
-              }
-  
               if (response.data && response.data.data) {
                   const { penaltyEndAt, penaltyReasonType } = response.data.data;
   
@@ -65,7 +52,17 @@ export const useMainpageHandlers = () => {
                   setPenaltyReason(penaltyReasonMap[penaltyReasonType]);
               }
           } catch (error) {
-              console.error("🚨 Error fetching user data:", error);
+            if (error.response && error.response.status === 401) {
+              console.warn('토큰이 만료됨. 새로고침 시도.');
+
+                accessToken = await refreshTokens();
+                if (accessToken) {
+                    return fetchUserData();
+                } else {
+                  console.error('토큰 갱신 실패. 로그아웃 필요.');
+                    return;
+                }
+            }
           }
       };
   

--- a/frontend/src/pages/Mainpage/handlers/PenaltyHandlers.jsx
+++ b/frontend/src/pages/Mainpage/handlers/PenaltyHandlers.jsx
@@ -27,15 +27,9 @@ export const usePenaltyHandlers = () => {
                     return;
                 }
     
-                const response = await axios.get("/api/users", {
+                let response = await axios.get("/api/users", {
                     headers: { Authorization: `Bearer ${accessToken}` },
                 });
-    
-                if (response.status === 401) {
-                    const newAccessToken = await refreshTokens();
-                    if (!newAccessToken) return;
-                    return fetchPenaltyData();
-                }
     
                 if (response.data && response.data.data) {
                     const { penaltyEndAt, penaltyReasonType } = response.data.data;
@@ -51,11 +45,14 @@ export const usePenaltyHandlers = () => {
                     } else {
                         setPenaltyEndAt("");
                     }
-    
                     setPenaltyReason(penaltyReasonMap[penaltyReasonType]);
                 }
             } catch (error) {
-                console.error("🚨 Error fetching penalty data:", error);
+                if (error.response && error.response.status === 401) {
+                    const newAccessToken = await refreshTokens();
+                    if (!newAccessToken) return;
+                    return fetchPenaltyData();
+                }
             }
         };
     


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- mainpagehandler와 penaltyhandler 중 at를 사용하는 함수의 refreshtokens 호출을 catch문으로 이동했다.

## 관련 이슈

- #341 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?
