### PR TITLE
[BE-#352] 예약 연장 처리 로직 개선

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
@@ -22,4 +22,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	List<Reservation> findByScheduleDateAndEndTime(LocalDate scheduleDate, LocalTime time);
 
 	List<Reservation> findByRoomNumberAndScheduleDateAndStartTime(String roomNumber, LocalDate scheduleDate, LocalTime startTime);
+
+	List<Reservation> findByFirstScheduleId(Long firstScheduleId);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/scheduler/ReservationUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/scheduler/ReservationUpdateScheduler.java
@@ -34,7 +34,7 @@ public class ReservationUpdateScheduler {
 		log.info("Processing update reservation status to complete for date: {} and time: {}", todayDate, todayTime);
 
 		reservationRepository.findByScheduleDateAndEndTime(todayDate, todayTime.minusMinutes(1)).forEach(reservation -> {
-			if(reservation.getStatus() == ReservationStatus.ENTRANCE){
+			if(reservation.getStatus() == ReservationStatus.ENTRANCE || reservation.getEndTime().isBefore(todayTime)){
 				reservation.markStatus(ReservationStatus.COMPLETED);
 			}
 			log.info("예약이 종료되었습니다.: {} (ID: {}) at {}", reservation.getUserEmail(), reservation.getId(), LocalDateTime.now());


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 예약 완료 처리 스케줄러가 예약 연장 여부를 확인하지 않은 부분을 수정했습니다.
- 패널티 여부를 우선적으로 확인하도록 개선했습니다.
- 동일 예약 조회 시, 스케줄 id를 활용하도록 했습니다.
- 다음 스케줄의 id가 이전 스케줄의 +1 인 점을 고려하여 다음 스케줄을 조회하도록 했습니다.
- 트랜잭션 어노테이션의 더티 체킹을 활용하였습니다.

## 관련 이슈

- #352 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 코드 컨벤션을 지켰나요?

## 스크린샷

필요한 경우 스크린샷을 첨부해주세요.

## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
