### PR TITLE
[Chore-#373] redis 비밀번호 설정을 통안 보안 강화

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/config/RedisConfig.java
+++ b/backend/src/main/java/com/ice/studyroom/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -17,9 +18,15 @@ public class RedisConfig {
 	@Value("${spring.redis.port}")
 	private int port;
 
+	@Value("${spring.redis.password}")
+	private String password;
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+		redisConfig.setPassword(password);
+
+		return new LettuceConnectionFactory(redisConfig);
 	}
 
 	@Bean

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.datasource.driver-class-name=${MYSQL_DRIVER}
 # Database Redis
 spring.redis.host=${REDIS_URL}
 spring.redis.port=${REDIS_PORT}
+spring.redis.password=${REDIS_PASSWORD}
 # JPA Basic Configuration
 spring.jpa.hibernate.ddl-auto=${DEV_JPA_DDL_AUTO}
 spring.jpa.show-sql=${DEV_JPA_SHOW_SQL}
@@ -24,7 +25,7 @@ spring.jackson.time-zone=Asia/Seoul
 jwt.secret=${JWT_SECRET}
 jwt.expiration=${JWT_EXPIRATION}
 jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION}
-# Gmail SMTP ??
+# Gmail SMTP
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=${MAIL_USERNAME}
@@ -39,10 +40,9 @@ spring.mail.properties.mail.smtp.writetimeout=5000
 schedule.insert.cron=0 0 6 * * 1-5
 # AESUtil setting
 aesutil_secret_key=${AESUTIL_SECRET_KEY}
-
+# Server setting
 server.address=0.0.0.0
 server.port=8080
-
 spring.timezone=Asia/Seoul
 
 


### PR DESCRIPTION
## PR 종류
- [x] 기능 개선

## 변경 사항
- redis비밀번호 설정
  - 외부에서 EC2 IP와 Redis Port로 접근하여 Redis 복제를 시도하는 문제 해결 가능
  - 복제를 시도함에 따라 Master Redis가 죽는 문제 해결 가능

## 관련 이슈
- #373 

## 체크리스트
- [x] 단순 설정 수정

## 스크린샷

## 기타
.env 업데이트 노션에 업로드 완료
