### PR TITLE
[BE-#395] 관리자 room_time_slot 선점, 해지, 조회 api 제작

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
@@ -111,21 +111,10 @@ public class AdminService {
 		return roomTimeSlots.stream().map(RoomScheduleInfoDto::from).toList();
 	}
 
-	//todo: RoomTimeSlot과 Schedule 사이에서 데이터 정합성 보장시키기
 	public List<AdminGetReservedResponse> getOccupyAndReservedRooms() {
 		// 선점된 방 엔티티만 가져오기
 		List<RoomTimeSlot> occupyRoomTimeSlots = roomTimeSlotRepository.findByStatus(ScheduleSlotStatus.UNAVAILABLE);
-
-		// 오늘 예약된 스케줄 엔티티만 가져오기
-		List<Schedule> reservationSchedules = scheduleRepository.findByScheduleDateAndStatus(LocalDate.now(), ScheduleSlotStatus.RESERVED);
-
-		// 오늘 스케줄 중 선점된 스케줄 엔티티만 가져오기
-		List<Schedule> occupySchedules = scheduleRepository.findByScheduleDateAndStatus(LocalDate.now(), ScheduleSlotStatus.RESERVED);
-
-		return Stream.concat(
-			occupyRoomTimeSlots.stream().map(AdminGetReservedResponse::from),
-			reservationSchedules.stream().map(AdminGetReservedResponse::from)
-		).toList();
+		return occupyRoomTimeSlots.stream().map(AdminGetReservedResponse::from).toList();
 	}
 
 	public List<AdminPenaltyRecordResponse> adminGetPenaltyRecords() {

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/request/AdminOccupyRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/request/AdminOccupyRequest.java
@@ -1,11 +1,17 @@
 package com.ice.studyroom.domain.admin.presentation.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
+import com.ice.studyroom.domain.admin.domain.type.DayOfWeekStatus;
+
 public record AdminOccupyRequest (
 	@NotEmpty(message = "선점을 원하는 시간대를 선택해주세요.")
-	List<Long> roomTimeSlotId
+	List<Long> roomTimeSlotId,
+
+	@NotNull(message = "선점하고자하는 날짜의 요일을 포함시켜주세요.")
+	DayOfWeekStatus dayOfWeek
 ) {
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/request/AdminReleaseRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/request/AdminReleaseRequest.java
@@ -2,10 +2,16 @@ package com.ice.studyroom.domain.admin.presentation.dto.request;
 
 import java.util.List;
 
+import com.ice.studyroom.domain.admin.domain.type.DayOfWeekStatus;
+
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record AdminReleaseRequest(
 	@NotEmpty(message = "선점 해지를 원하는 시간대를 선택해주세요.")
-	List<Long> roomTimeSlotId
+	List<Long> roomTimeSlotId,
+
+	@NotNull(message = "선점을 해지하고자 하는 날짜의 요일을 포함시켜주세요.")
+	DayOfWeekStatus dayOfWeek
 ) {
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/scheduler/RoomTimeSlotScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/scheduler/RoomTimeSlotScheduler.java
@@ -1,0 +1,33 @@
+package com.ice.studyroom.domain.admin.scheduler;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.ice.studyroom.domain.admin.domain.entity.RoomTimeSlot;
+import com.ice.studyroom.domain.admin.infrastructure.persistence.RoomTimeSlotRepository;
+import com.ice.studyroom.domain.reservation.domain.type.ScheduleSlotStatus;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class RoomTimeSlotScheduler {
+
+	private final RoomTimeSlotRepository roomTimeSlotRepository;
+
+	@Transactional
+	@Scheduled(cron = "0 0 0 * * 1")
+	public void roomTimeSlotInitScheduler() {
+		log.info("RoomTimeSlot init scheduler 가 동작합니다.");
+		List<RoomTimeSlot> unavailableRoomTimeSlotList = roomTimeSlotRepository.findByStatus(ScheduleSlotStatus.UNAVAILABLE);
+		unavailableRoomTimeSlotList.forEach(roomTimeSlot -> roomTimeSlot.updateStatus(ScheduleSlotStatus.AVAILABLE));
+		log.info("RoomTimeSlot init scheduler 가 정상적으로 동작되었습니다.");
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -197,7 +197,7 @@ public class ReservationService {
 
 			schedule.setCurrentRes(schedule.getCurrentRes() + 1); // 개인예약은 현재사용인원에서 +1 진행
 			if (schedule.getCurrentRes() == schedule.getCapacity()) { //예약 후 현재인원 == 방수용인원 경우 RESERVE
-				schedule.reserve();
+				schedule.updateStatus(ScheduleSlotStatus.RESERVED);
 			}
 		}
 
@@ -300,7 +300,7 @@ public class ReservationService {
 
 		for (Schedule schedule : schedules) {
 			schedule.setCurrentRes(totalParticipants); // 현재 사용 인원을 예약자 + 참여자 숫자로 지정
-			schedule.reserve();
+			schedule.updateStatus(ScheduleSlotStatus.RESERVED);
 		}
 
 		scheduleRepository.saveAll(schedules);
@@ -407,7 +407,7 @@ public class ReservationService {
 				res.extendReservation(nextSchedule.getId(), nextSchedule.getEndTime());
 			}
 
-			nextSchedule.reserve();
+			nextSchedule.updateStatus(ScheduleSlotStatus.RESERVED);
 			nextSchedule.setCurrentRes(reservationEmails.size());
 		}else{
 			if(reservation.getStatus() != ReservationStatus.ENTRANCE){
@@ -416,7 +416,7 @@ public class ReservationService {
 			reservation.extendReservation(nextSchedule.getId(), nextSchedule.getEndTime());
 			nextSchedule.setCurrentRes(nextSchedule.getCurrentRes() + 1);
 			if(!nextSchedule.isCurrentResLessThanCapacity()){
-				nextSchedule.reserve();
+				nextSchedule.updateStatus(ScheduleSlotStatus.RESERVED);
 			}
 		}
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Schedule.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Schedule.java
@@ -95,6 +95,10 @@ public class Schedule {
 		this.status = ScheduleSlotStatus.RESERVED;
 	}
 
+	public void unAvailable() {
+		this.status = ScheduleSlotStatus.UNAVAILABLE;
+	}
+
 	public void cancel() {
 		this.currentRes--;
 		ifCurrentResZeroThanMakeAvailable();

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Schedule.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Schedule.java
@@ -91,12 +91,8 @@ public class Schedule {
 		return currentRes < capacity;
 	}
 
-	public void reserve() {
-		this.status = ScheduleSlotStatus.RESERVED;
-	}
-
-	public void unAvailable() {
-		this.status = ScheduleSlotStatus.UNAVAILABLE;
+	public void updateStatus(ScheduleSlotStatus newStatus) {
+		this.status = newStatus;
 	}
 
 	public void cancel() {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ScheduleRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ScheduleRepository.java
@@ -13,4 +13,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 	List<Schedule> findByScheduleDate(LocalDate date);
 
 	List<Schedule> findByScheduleDateAndStatus(LocalDate date, ScheduleSlotStatus status);
+
+	List<Schedule> findByScheduleDateAndRoomTimeSlotIdIn(LocalDate date, List<Long> roomTimeSlotId);
+
 }

--- a/frontend/src/pages/Mainpage/Adminpage/useAdminPageHandler.jsx
+++ b/frontend/src/pages/Mainpage/Adminpage/useAdminPageHandler.jsx
@@ -15,11 +15,11 @@ const useAdminPageHandler = () => {
   const [dayOfWeek, setDayOfWeek] = useState(getTodayDayOfWeek());
 
   const dayMapping = {
-    '월': 'Monday',
-    '화': 'Tuesday',
-    '수': 'Wednesday',
-    '목': 'Thursday',
-    '금': 'Friday'
+    '월': 'MONDAY',
+    '화': 'TUESDAY',
+    '수': 'WEDNESDAY',
+    '목': 'THURSDAY',
+    '금': 'FRIDAY'
   };
 
   useEffect(() => {


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 관리자의 room_time_slot 선점,해지,조회 기능을 구현
- 당일 선점을 할 경우 schdule에 직접 업데이트 내용이 반영됩니다.

## 관련 이슈

#395 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [ ] 코드 컨벤션을 지켰나요?

## 스크린샷

필요한 경우 스크린샷을 첨부해주세요.

## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
