### PR TITLE
[FE-#407] 관리자 페이지 선점 완료, 해지시 ui 업데이트 및 탭 상태 저장

### DIFF
--- a/frontend/src/pages/Mainpage/Adminpage/Adminpage.jsx
+++ b/frontend/src/pages/Mainpage/Adminpage/Adminpage.jsx
@@ -1,5 +1,5 @@
 import { React, useState, useEffect } from 'react';
-import { Home, LogOut, Monitor } from 'lucide-react';
+import { Home, LogOut } from 'lucide-react';
 import useAdminPageHandler from './useAdminPageHandler';
 import PenaltyManagement from './PenaltyManagement';
 import BookingManagement from './BookingManagement';

--- a/frontend/src/pages/Mainpage/Adminpage/BookingManagement.jsx
+++ b/frontend/src/pages/Mainpage/Adminpage/BookingManagement.jsx
@@ -182,8 +182,6 @@ const BookingManagement = ({ rooms }) => {
       const responseData = await response.json();
       if (!response.ok) throw new Error(responseData.message || "해제 요청 실패");
   
-      console.log("✅ 해제 성공:", responseData.data.message || "OK");
-  
       setBookings(prev => ({
         ...prev,
         [selectedDay]: {
@@ -196,6 +194,8 @@ const BookingManagement = ({ rooms }) => {
   
       setIsModalOpen(false);
       setSelectedTimes([]);
+      alert("해제가 완료되었습니다!");
+      window.location.reload();
     } catch (error) {
       console.error("❌ 해제 실패:", error.message);
       alert("해제에 실패했습니다. 다시 시도해주세요.");

--- a/frontend/src/pages/Mainpage/Adminpage/useAdminPageHandler.jsx
+++ b/frontend/src/pages/Mainpage/Adminpage/useAdminPageHandler.jsx
@@ -6,7 +6,12 @@ const getTodayDayOfWeek = () => {
 };
 
 const useAdminPageHandler = () => {
-  const [activeTab, setActiveTab] = useState('booking');
+
+  const getInitialTab = () => {
+    return sessionStorage.getItem("adminActiveTab") || "booking";
+  };
+
+  const [activeTab, setActiveTab] = useState(getInitialTab);
   const [selectedRoom, setSelectedRoom] = useState('');
   const [selectedTimes, setSelectedTimes] = useState([]);
   const [roomsState, setRoomsState] = useState([]);
@@ -123,43 +128,9 @@ const useAdminPageHandler = () => {
     return merged;
   };
 
-  const penaltyData = useMemo(() => [
-    {
-      name: '김원빈',
-      studentId: '201900969',
-      reason: '취소 패널티 2회',
-      issueDate: '2024-01-20',
-      expiryDate: '2024-01-30',
-      status: 'active'
-    },
-    {
-      name: '양재원',
-      studentId: '201900123',
-      reason: '예약 불참 2회',
-      issueDate: '2024-01-15',
-      expiryDate: '2024-01-25',
-      status: 'inactive'
-    },
-    {
-      name: '정순인',
-      studentId: '201800234',
-      reason: '취소 패널티 2회',
-      issueDate: '2024-01-20',
-      expiryDate: '2024-01-30',
-      status: 'active'
-    },
-    {
-      name: '도성현',
-      studentId: '201900345',
-      reason: '취소 패널티 2회',
-      issueDate: '2024-01-20',
-      expiryDate: '2024-01-30',
-      status: 'active'
-    }
-  ], []);
-
   const handleTabChange = useCallback((tab) => {
     setActiveTab(tab);
+    sessionStorage.setItem("adminActiveTab", tab);
   }, []);
 
   const handleRoomSelect = useCallback((roomId) => {
@@ -238,6 +209,7 @@ const handleOccupy = async () => {
     }
 
     alert("예약이 완료되었습니다!");
+    window.location.reload();
   } catch (error) {
     alert("예약에 실패했습니다. 다시 시도해주세요.");
   }
@@ -258,7 +230,6 @@ const handleOccupy = async () => {
     setDayOfWeek,
     rooms: roomsState,
     timeSlots,
-    penaltyData,
     availableRoomsCount,
     
     // Handlers


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- 탭 상태를 저장하여 새로고침 해도 기존 탭이 유지되도록 변경했다.
- 선점 완료 및 해제시 새로고침을 통해 ui에 바로 업데이트 되도록 변경했다.

## 관련 이슈

- #407 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?
