### PR TITLE
[BE-#410] reservation 테이블 스키마에 member 외래키 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 - 한국외국어대학교 정보통신공학과 스터디룸 예약 시스템 프로젝트
 
+## 🙋‍♂️ 팀원 소개
+
+<div align="center">
+
+| 도성현 | 심재성 | 이호진 | 김원빈 | 양재원 |
+|:------:|:------:|:------:|:------:|:------:|
+| <img src="https://avatars.githubusercontent.com/u/52828205?v=4" alt="도성현" width="150"> | <img src="https://avatars.githubusercontent.com/u/89987940?v=4" alt="심재성" width="150"> | <img src="https://avatars.githubusercontent.com/u/128957586?v=4" alt="이호진" width="150"> | <img src="https://avatars.githubusercontent.com/u/67516846?v=4" alt="김원빈" width="150"> | <img src="https://avatars.githubusercontent.com/u/101964792?v=4" alt="양재원" width="150"> |
+| BE | BE | BE | FE | FE|
+| [GitHub](https://github.com/glaxyt) | [GitHub](https://github.com/simjaesung) | [GitHub](https://github.com/HoreungHoreung) | [GitHub](https://github.com/been12151) | [GitHub](https://github.com/jay-onee) |
+
+</div>
+
 ## 🛠️ 기술 스택
 
 ### 🎨 Frontend

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -186,7 +186,7 @@ public class ReservationService {
 		// 예약 객체 생성 및 저장
 		String userName = reserver.getName();
 		String userEmail = reserver.getEmail().getValue();
-		Reservation reservation = Reservation.from(schedules, userEmail, userName, true);
+		Reservation reservation = Reservation.from(schedules, userEmail, userName, true, reserver);
 		reservationRepository.save(reservation);
 
 		// QR 코드 생성 및 저장
@@ -240,8 +240,8 @@ public class ReservationService {
 		uniqueEmails.add(reserverEmail); // 예약자 이메일 포함
 
 		// 예약자와 참여자의 이메일을 저장 (이름 포함)
-		Map<String, String> emailToNameMap = new HashMap<>();
-		emailToNameMap.put(reserverEmail, reserver.getName());
+		Map<String, Member> emailToMemberMap = new HashMap<>();
+		emailToMemberMap.put(reserverEmail, reserver);
 
 		// 참여자 리스트 추가 (중복 검사 및 user_name 조회)
 		if (!ObjectUtils.isEmpty(request.participantEmail())) {
@@ -266,7 +266,7 @@ public class ReservationService {
 					}
 				}
 
-				emailToNameMap.put(email, participant.getName());
+				emailToMemberMap.put(email, participant);
 			}
 		}
 
@@ -288,9 +288,9 @@ public class ReservationService {
 
 		// 예약 생성 및 저장
 		for (String email : uniqueEmails) {
-			String userName = emailToNameMap.get(email);
+			Member member = emailToMemberMap.get(email);
 			boolean isHolder = email.equals(reserverEmail);
-			reservations.add(Reservation.from(schedules, email, userName, isHolder));
+			reservations.add(Reservation.from(schedules, email, member.getName(), isHolder, member));
 		}
 
 		reservationRepository.saveAll(reservations);

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
+import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
-import com.ice.studyroom.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.type.StatusCode;
 
@@ -15,9 +15,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -38,6 +41,10 @@ public class Reservation {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
 
 	@Column(name = "first_schedule_id")
 	private Long firstScheduleId;
@@ -123,7 +130,7 @@ public class Reservation {
 		this.updatedAt = LocalDateTime.now();
 	}
 
-	public static Reservation from(List<Schedule> schedules, String email, String userName, boolean isReservationHolder) {
+	public static Reservation from(List<Schedule> schedules, String email, String userName, boolean isReservationHolder, Member member) {
 		if (schedules == null || schedules.isEmpty()) {
 			throw new BusinessException(StatusCode.BAD_REQUEST, "Schedules List가 비어있습니다.");
 		}
@@ -138,6 +145,7 @@ public class Reservation {
 		return Reservation.builder()
 			.firstScheduleId(firstSchedule.getId())
 			.secondScheduleId(secondSchedule != null ? secondSchedule.getId() : null)
+			.member(member)
 			.userEmail(email)
 			.userName(userName)
 			.scheduleDate(firstSchedule.getScheduleDate())


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [x] 새로운 기능
 
## 변경 사항

- 테이블 정규화에 의한 점진적 개선을 하고 있습니다.
- 기존에 외래키로 등록되어있지않던 member 외래키를 등록해주었습니다.

## 관련 이슈

- #410 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
```java
 public class Reservation {

	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	private Long id;

	@ManyToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "member_id")
	private Member member;

        / .. 다른 코드
}
```
ManyToOne 관계로 지정해주었으며, 즉시로딩이 아닌 지연로딩으로 등록해서 N+1문제를 최소화 했습니다.  
프로젝트 전체적으로도 즉시로딩을 사용할 일은 없어보이니 추후에 추가될 외래키도 지연 로딩으로 부탁드리겠습니다.  

```
ALTER TABLE reservation
ADD COLUMN member_id BIGINT AFTER id;

ALTER TABLE reservation
ADD CONSTRAINT fk_reservation_member
FOREIGN KEY (member_id) REFERENCES member(id);
```

프로덕션 DB에 추가해주었습니다.  
이후 reservation 생성 시에 member를 등록해주었습니다.  

## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
