### PR TITLE
[BE-#412] 예약 조회, 예약 연장 삭제 될 컬럼인(userName, userEmail) 의존성 제거 

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -95,9 +95,6 @@ public class Reservation {
 		return status == ReservationStatus.ENTRANCE;
 	}
 
-	// TODO: 삭제 예정인 메서드 사유: userEmail, userName 삭제 예정
-	public boolean matchEmail(String email) { return userEmail.equals(email); }
-
 	public boolean isOwnedBy(String rawEmail) {
 		return this.member.getEmail().equals(Email.of(rawEmail));
 	}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
 import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.type.StatusCode;
@@ -90,11 +91,16 @@ public class Reservation {
 	@Builder.Default
 	private LocalDateTime updatedAt = LocalDateTime.now();
 
-	public boolean isReserved() {
-		return status == ReservationStatus.RESERVED;
+	public boolean isEntered() {
+		return status == ReservationStatus.ENTRANCE;
 	}
 
+	// TODO: 삭제 예정인 메서드 사유: userEmail, userName 삭제 예정
 	public boolean matchEmail(String email) { return userEmail.equals(email); }
+
+	public boolean isOwnedBy(String rawEmail) {
+		return this.member.getEmail().equals(Email.of(rawEmail));
+	}
 
 	// 정상 입실인지 지각인지 노쇼인지 판단하는 코드
 	public ReservationStatus checkAttendanceStatus(LocalDateTime now) {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
@@ -9,11 +9,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-	List<Reservation> findByUserEmail(String email);
+	List<Reservation> findByMember(Member member);
 
 	List<Reservation> findByScheduleDateAndEndTime(LocalDate scheduleDate, LocalTime time);
 

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/ReservationCancelTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/ReservationCancelTest.java
@@ -105,7 +105,7 @@ class ReservationCancelTest {
 		// JWT를 통한 사용자 정보를 토대로, 본인의 예약인지 확인
 		when(tokenService.extractEmailFromAccessToken(token)).thenReturn(userEmail);
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
-		when(reservation.matchEmail(userEmail)).thenReturn(true);
+		when(reservation.isOwnedBy(userEmail)).thenReturn(true);
 
 		when(clock.instant()).thenReturn(fixedNow.atZone(java.time.ZoneId.systemDefault()).toInstant());
 		lenient().when(clock.getZone()).thenReturn(ZoneId.systemDefault());
@@ -173,7 +173,7 @@ class ReservationCancelTest {
 		// JWT를 통한 사용자 정보를 토대로, 본인의 예약인지 확인
 		when(tokenService.extractEmailFromAccessToken(token)).thenReturn(userEmail);
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
-		when(reservation.matchEmail(userEmail)).thenReturn(true);
+		when(reservation.isOwnedBy(userEmail)).thenReturn(true);
 
 		when(reservation.getFirstScheduleId()).thenReturn(100L);
 		when(reservation.getSecondScheduleId()).thenReturn(101L);
@@ -226,7 +226,7 @@ class ReservationCancelTest {
 		Long reservationId = 1L;
 		String token = "Bearer valid_token";
 		when(tokenService.extractEmailFromAccessToken(token)).thenReturn("wrong@example.com");
-		when(reservation.matchEmail("wrong@example.com")).thenReturn(false);
+		when(reservation.isOwnedBy("wrong@example.com")).thenReturn(false);
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
 
 		// when & then
@@ -282,7 +282,7 @@ class ReservationCancelTest {
 		lenient().when(clock.getZone()).thenReturn(ZoneId.systemDefault());
 
 		when(tokenService.extractEmailFromAccessToken(token)).thenReturn(userEmail);
-		when(reservation.matchEmail(userEmail)).thenReturn(true);
+		when(reservation.isOwnedBy(userEmail)).thenReturn(true);
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
 
 		when(reservation.getFirstScheduleId()).thenReturn(100L);
@@ -351,7 +351,7 @@ class ReservationCancelTest {
 		lenient().when(clock.getZone()).thenReturn(ZoneId.systemDefault());
 
 		when(tokenService.extractEmailFromAccessToken(token)).thenReturn(userEmail);
-		when(reservation.matchEmail(userEmail)).thenReturn(true);
+		when(reservation.isOwnedBy(userEmail)).thenReturn(true);
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
 
 		when(reservation.getFirstScheduleId()).thenReturn(100L);
@@ -463,7 +463,7 @@ class ReservationCancelTest {
 
 		// 예약 정보: 시작 시각 13:00 → 현재 시간보다 이전
 		when(tokenService.extractEmailFromAccessToken(token)).thenReturn(userEmail);
-		when(reservation.matchEmail(userEmail)).thenReturn(true);
+		when(reservation.isOwnedBy(userEmail)).thenReturn(true);
 		when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
 
 		when(reservation.getFirstScheduleId()).thenReturn(100L);


### PR DESCRIPTION
## PR 종류

- [x] 리팩토링


## 변경 사항

- 예약 조회, 예약 연장 삭제될 컬럼인(userName, userEmail) 의존성을 제거해주었습니다.

## 관련 이슈

- #412 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
### 삭제될 컬럼 의존성 제거
```
public class Reservation {
       // .. 다른 코드
	public boolean isEntered() {
		return status == ReservationStatus.ENTRANCE;
	}

	public boolean isOwnedBy(String rawEmail) {
		return this.member.getEmail().equals(Email.of(rawEmail));
	}
       // .. 다른 코드
}
```
도메인에서 관리 가능한 메서드는 엔티티에 추가해주었습니다.  

### 개인 예약 경우에도 같은 시간대의 예약자의 패널티를 확인하는 로직 순서 이동
```
if (nextSchedule.getRoomType() == RoomType.GROUP) {
	// 그룹 예약 이기에 같은 시간대의 예약 레코드를 모두 가져온다(참여자 검증 필요). memeber 1차 캐시되며 이 값을 사용할 예정
	List<Reservation> reservations = reservationRepository.findByFirstScheduleId(reservation.getFirstScheduleId());

	// 그룹 예약 이기에 같은 시간대의 예약 레코드를 모두 가져온다(참여자 검증 필요). memeber 1차 캐시되며 이 값을 사용할 예정
	List<Reservation> reservations = reservationRepository.findByFirstScheduleId(reservation.getFirstScheduleId());

	// 패널티를 부여받고 있는 참여자가 존재할 경우 예약 연장 진행 불가
	for (Reservation res : reservations) {
		if (res.getMember().isPenalty()) {
			throw new BusinessException(StatusCode.FORBIDDEN, "패널티가 있는 멤버로 인해 연장이 불가능합니다.");
				}
			}

```
개인 예약의 경우 동일 시간대의 다른 개인 예약자가 패널티를 받는 경우 연장이 불가한 상황입니다.  
따라서 그룹 예약의 경우에만 동일 시간대의 예약자를 지연로딩을 통해 조회하는 로직으로 수정했습니다.
## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
