### PR TITLE
[BE-#417] 개인 예약 테스트 코드 작성 및 비즈니스 로직 개선

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/Email.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/Email.java
@@ -1,6 +1,7 @@
 package com.ice.studyroom.domain.membership.domain.vo;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.type.StatusCode;
@@ -34,5 +35,13 @@ public class Email implements Serializable {
 		if (!value.endsWith("@hufs.ac.kr")) {
 			throw new BusinessException(StatusCode.BAD_REQUEST, "이메일은 @hufs.ac.kr로 끝나야 합니다.");
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof Email)) return false;
+		Email email = (Email) o;
+		return Objects.equals(value, email.value);
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -460,7 +460,7 @@ public class ReservationService {
 	}
 
 	private void validateSchedulesAvailable(List<Schedule> schedules) {
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime now = LocalDateTime.now(clock);
 
 		if (schedules.stream().anyMatch(schedule -> {
 			LocalDateTime scheduleStartDateTime = LocalDateTime.of(schedule.getScheduleDate(), schedule.getStartTime());
@@ -482,7 +482,7 @@ public class ReservationService {
 		}
 	}
 
-	private void sendReservationSuccessEmail(RoomType type, String reserverEmail, Set<String> participantsEmail,
+	protected void sendReservationSuccessEmail(RoomType type, String reserverEmail, Set<String> participantsEmail,
 		Schedule schedule) {
 
 		String subject = "[ICE-STUDYRES] 스터디룸 예약이 완료되었습니다.";

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ScheduleRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ScheduleRepository.java
@@ -12,6 +12,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
 	List<Schedule> findByScheduleDate(LocalDate date);
 
+	List<Schedule> findAllByIdIn(List<Long> ids);
+
 	List<Schedule> findByScheduleDateAndStatus(LocalDate date, ScheduleSlotStatus status);
 
 	List<Schedule> findByScheduleDateAndRoomTimeSlotIdIn(LocalDate date, List<Long> roomTimeSlotId);

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -18,11 +18,4 @@ public record CreateReservationRequest(
 			throw new BusinessException(StatusCode.BAD_REQUEST, "예약은 1~2시간만 가능합니다.");
 		}
 	}
-
-	public boolean isConsecutiveReservation() {
-		return scheduleId.length == 2;
-	}
-
-	public void validateScheduleIds() {
-	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -7,10 +7,7 @@ import com.ice.studyroom.global.type.StatusCode;
 
 public record CreateReservationRequest(
 	Long[] scheduleId,
-	String[] participantEmail,
-	String roomNumber,
-	LocalTime startTime,
-	LocalTime endTime
+	String[] participantEmail
 ) {
 	public CreateReservationRequest {
 		// 생성자 내부에서 기본 유효성 검사 수행

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -191,6 +191,52 @@ class IndividualReservationTest {
 	}
 
 	/**
+	 * 📌 테스트명: 예약_시작시간_직전에_예약_시도_예외_발생
+	 *
+	 * ✅ 목적:
+	 *   - 사용자가 예약 시작 시간과 **정확히 같은 시간**에 예약을 시도할 경우,
+	 *     예약이 거부되는지 검증한다. (경계값 테스트)
+	 *
+	 * 🧪 시나리오 설명:
+	 *   1. 예약할 스케줄: 13:00 시작
+	 *   2. 현재 시간: 13:00 (== 시작 시간)
+	 *   3. 스케줄 상태: AVAILABLE, INDIVIDUAL, 수용 가능
+	 *   4. 회원: 존재하고 패널티 없음
+	 *   5. 중복 예약 없음
+	 *   6. 예약 시도 시, validateSchedulesAvailable()에서 시간 조건에 걸려 예외 발생
+	 *
+	 * 📌 관련 비즈니스 규칙:
+	 *   - 스케줄 시작 시간이 현재 시간보다 **이후**여야 예약 가능
+	 *
+	 * 🧩 검증 포인트:
+	 *   - 예외 메시지가 "예약이 불가능합니다."인지 확인
+	 *   - reservationRepository, scheduleRepository, qrCodeService는 호출되지 않아야 함
+	 *
+	 * ✅ 기대 결과:
+	 *   - 예약이 생성되지 않으며 예외가 발생
+	 */
+	@Test
+	@DisplayName("스케줄 시작 시간과 동일한 시간에 예약 시도 시 예외 발생")
+	void 예약_시작시간_직전에_예약_시도_예외_발생() {
+		// given
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{ firstScheduleId },
+			new String[]{}
+		);
+
+		시간_고정_셋업(13, 0);
+		스케줄_설정(firstSchedule, firstScheduleId, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 0);
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () ->
+			reservationService.createIndividualReservation(token, request)
+		);
+
+		assertThat(ex.getMessage()).isEqualTo("예약이 불가능합니다.");
+		verify(reservationRepository, never()).save(any());
+	}
+
+	/**
 	 * 📌 테스트명: 사용_불가능한_스케줄로_예약_시도는_예외_발생
 	 *
 	 * ✅ 목적:

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -82,10 +82,7 @@ class IndividualReservationTest {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
 			new Long[]{firstScheduleId},
-			new String[]{}, // 개인 예약이라 참여자 없음
-			"305-1",        // 예시 방 번호
-			LocalTime.of(12, 0),
-			LocalTime.of(13, 0)
+			new String[]{} // 개인 예약이라 참여자 없음
 		);
 
 		시간_고정_셋업(12, 30);
@@ -115,10 +112,7 @@ class IndividualReservationTest {
 		Long secondSchuduleId = 2L;
 		CreateReservationRequest request = new CreateReservationRequest(
 			new Long[]{firstScheduleId, secondSchuduleId},
-			new String[]{}, // 개인 예약이라 참여자 없음
-			"305-1",        // 예시 방 번호
-			LocalTime.of(12, 0),
-			LocalTime.of(13, 0)
+			new String[]{} // 개인 예약이라 참여자 없음
 		);
 
 		시간_고정_셋업(12, 30);
@@ -147,10 +141,7 @@ class IndividualReservationTest {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
 			new Long[]{ firstScheduleId },
-			new String[]{}, // 개인 예약이라 참여자 없음
-			"305-1",        // 예시 방 번호
-			LocalTime.of(12, 0),
-			LocalTime.of(13, 0)
+			new String[]{}// 개인 예약이라 참여자 없음
 		);
 
 		given(scheduleRepository.findById(firstScheduleId)).willReturn(Optional.of(firstSchedule));
@@ -173,10 +164,7 @@ class IndividualReservationTest {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
 			new Long[]{firstScheduleId},
-			new String[]{},
-			"305-1",
-			LocalTime.of(12, 0),
-			LocalTime.of(13, 0)
+			new String[]{}
 		);
 
 		시간_고정_셋업(12, 30);
@@ -197,10 +185,7 @@ class IndividualReservationTest {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
 			new Long[]{firstScheduleId},
-			new String[]{},
-			"305-1",
-			LocalTime.of(12, 0),
-			LocalTime.of(13, 0)
+			new String[]{}
 		);
 
 		시간_고정_셋업(12, 30);
@@ -224,10 +209,7 @@ class IndividualReservationTest {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
 			new Long[]{firstScheduleId},
-			new String[]{}, // 개인 예약이라 참여자 없음
-			"305-1",        // 예시 방 번호
-			LocalTime.of(12, 0),
-			LocalTime.of(13, 0)
+			new String[]{}
 		);
 
 		String name = "도성현";
@@ -251,10 +233,7 @@ class IndividualReservationTest {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
 			new Long[]{firstScheduleId},
-			new String[]{}, // 개인 예약이라 참여자 없음
-			"305-1",        // 예시 방 번호
-			LocalTime.of(12, 0),
-			LocalTime.of(13, 0)
+			new String[]{}
 		);
 
 		String name = "도성현";

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -1,0 +1,336 @@
+package com.ice.studyroom.domain.reservation.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+import com.ice.studyroom.domain.identity.domain.service.QRCodeService;
+import com.ice.studyroom.domain.identity.domain.service.TokenService;
+import com.ice.studyroom.domain.identity.infrastructure.security.QRCodeUtil;
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.vo.Email;
+import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
+import com.ice.studyroom.domain.reservation.domain.type.ScheduleSlotStatus;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ScheduleRepository;
+import com.ice.studyroom.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import com.ice.studyroom.global.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class IndividualReservationTest {
+
+	@Spy
+	@InjectMocks
+	private ReservationService reservationService;
+	@Mock
+	private ReservationRepository reservationRepository;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private ScheduleRepository scheduleRepository;
+	@Mock
+	private TokenService tokenService;
+	@Mock
+	private Clock clock;
+	@Mock
+	private Schedule firstSchedule;
+	@Mock
+	private Schedule secondSchedule;
+	@Mock
+	private QRCodeUtil qrCodeUtil;
+	@Mock
+	private QRCodeService qrCodeService;
+
+	private String email;
+	private String token;
+	private Long firstScheduleId;
+
+
+	@BeforeEach
+	void setUp() {
+		email = "user@hufs.ac.kr";
+		token = "Bearer valid_token";
+		firstScheduleId = 1L;
+
+		firstSchedule = mock(Schedule.class);
+		secondSchedule = mock(Schedule.class);
+	}
+
+	@DisplayName("정상적으로 스케줄을 1시간 예약 성공")
+	@Test
+	void 개인_예약_1시간_성공() {
+		// given
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{firstScheduleId},
+			new String[]{}, // 개인 예약이라 참여자 없음
+			"305-1",        // 예시 방 번호
+			LocalTime.of(12, 0),
+			LocalTime.of(13, 0)
+		);
+
+		시간_고정_셋업(12, 30);
+		스케줄_설정(firstSchedule, firstScheduleId, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
+		스케줄_인원_제한_설정(firstSchedule, 6, 0);
+		예약자_패널티_설정(false);
+		QrCode_생성();
+
+		// 이메일 발송 제거
+		doNothing().when(reservationService).sendReservationSuccessEmail(any(), any(), any(), any());
+
+		// when
+		String result = reservationService.createIndividualReservation(token, request);
+
+		// then
+		assertEquals("Success", result);
+		verify(scheduleRepository).saveAll(anyList());
+		verify(reservationRepository).save(any(Reservation.class));
+		verify(qrCodeService).saveQRCode(eq(email), eq(123L), eq(request.scheduleId().toString()), eq("fake-qrcode"));
+	}
+
+	@DisplayName("정상적으로 스케줄을 2시간 예약 성공")
+	@Test
+	void 개인_예약_2시간_성공() {
+		// given
+		String name = "홍길동";
+		Long secondSchuduleId = 2L;
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{firstScheduleId, secondSchuduleId},
+			new String[]{}, // 개인 예약이라 참여자 없음
+			"305-1",        // 예시 방 번호
+			LocalTime.of(12, 0),
+			LocalTime.of(13, 0)
+		);
+
+		시간_고정_셋업(12, 30);
+		스케줄_설정(firstSchedule, firstScheduleId, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
+		스케줄_인원_제한_설정(firstSchedule, 6, 0);
+		스케줄_설정(secondSchedule, secondSchuduleId, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
+		스케줄_인원_제한_설정(secondSchedule, 6, 0);
+		예약자_패널티_설정(false);
+		QrCode_생성();
+
+		doNothing().when(reservationService).sendReservationSuccessEmail(any(), any(), any(), any());
+
+		// when
+		String result = reservationService.createIndividualReservation(token, request);
+
+		// then
+		assertEquals("Success", result);
+		verify(scheduleRepository).saveAll(anyList());
+		verify(reservationRepository).save(any(Reservation.class));
+		verify(qrCodeService).saveQRCode(eq(email), eq(123L), eq(request.scheduleId().toString()), eq("fake-qrcode"));
+	}
+
+	@DisplayName("사용 불가능한 스케줄로 예약 시도는 예외 발생")
+	@Test
+	void 사용_불가능한_스케줄로_예약_시도는_예외_발생() {
+		// given
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{ firstScheduleId },
+			new String[]{}, // 개인 예약이라 참여자 없음
+			"305-1",        // 예시 방 번호
+			LocalTime.of(12, 0),
+			LocalTime.of(13, 0)
+		);
+
+		given(scheduleRepository.findById(firstScheduleId)).willReturn(Optional.of(firstSchedule));
+		given(firstSchedule.getStatus()).willReturn(ScheduleSlotStatus.RESERVED); // not AVAILABLE
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () ->
+			reservationService.createIndividualReservation(token, request)
+		);
+
+		assertThat(ex.getMessage()).isEqualTo("존재하지 않거나 사용 불가능한 스케줄입니다.");
+
+		verify(reservationRepository, never()).save(any());
+		verify(qrCodeService, never()).saveQRCode(any(), any(), any(), any());
+	}
+
+	@DisplayName("단체전용방 예약 시도는 예외 발생")
+	@Test
+	void 단체전용방_예약_시도는_예외_발생() {
+		// given
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{firstScheduleId},
+			new String[]{},
+			"305-1",
+			LocalTime.of(12, 0),
+			LocalTime.of(13, 0)
+		);
+
+		시간_고정_셋업(12, 30);
+		스케줄_설정(firstSchedule, firstScheduleId, ScheduleSlotStatus.AVAILABLE, RoomType.GROUP, 13, 30);
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () ->
+			reservationService.createIndividualReservation(token, request)
+		);
+
+		assertThat(ex.getMessage()).isEqualTo("해당 방은 단체예약 전용입니다.");
+		verify(reservationRepository, never()).save(any());
+	}
+
+	@DisplayName("존재하지 않는 회원의 예약 요청은 예외 발생")
+	@Test
+	void 존재하지_않는_회원의_예약_요청은_예외_발생() {
+		// given
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{firstScheduleId},
+			new String[]{},
+			"305-1",
+			LocalTime.of(12, 0),
+			LocalTime.of(13, 0)
+		);
+
+		시간_고정_셋업(12, 30);
+		스케줄_설정(firstSchedule, firstScheduleId, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
+
+		given(tokenService.extractEmailFromAccessToken(token)).willReturn(email);
+		given(memberRepository.findByEmail(Email.of(email))).willReturn(Optional.empty());
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () ->
+			reservationService.createIndividualReservation(token, request)
+		);
+
+		assertThat(ex.getMessage()).isEqualTo("예약자 이메일이 존재하지 않습니다: " + email);
+		verify(reservationRepository, never()).save(any());
+	}
+
+	@DisplayName("패널티를 받은 회원의 예약 요청은 예외 발생")
+	@Test
+	void 패널티를_받은_회원의_예약_요청은_예외_발생() {
+		// given
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{firstScheduleId},
+			new String[]{}, // 개인 예약이라 참여자 없음
+			"305-1",        // 예시 방 번호
+			LocalTime.of(12, 0),
+			LocalTime.of(13, 0)
+		);
+
+		String name = "도성현";
+
+		시간_고정_셋업(12, 30);
+		스케줄_설정(firstSchedule, firstScheduleId, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
+		예약자_패널티_설정(true);
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () ->
+			reservationService.createIndividualReservation(token, request)
+		);
+
+		assertThat(ex.getMessage()).isEqualTo("사용정지 상태입니다.");
+		verify(reservationRepository, never()).save(any());
+	}
+
+	@DisplayName("예약이 중복된다면 에러 발생")
+	@Test
+	void 예약이_중복된다면_에러_발생() {
+		// given
+		CreateReservationRequest request = new CreateReservationRequest(
+			new Long[]{firstScheduleId},
+			new String[]{}, // 개인 예약이라 참여자 없음
+			"305-1",        // 예시 방 번호
+			LocalTime.of(12, 0),
+			LocalTime.of(13, 0)
+		);
+
+		String name = "도성현";
+
+		시간_고정_셋업(12, 30);
+		스케줄_설정(firstSchedule, firstScheduleId, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
+		// 회원 정보 찾기
+		given(tokenService.extractEmailFromAccessToken(token)).willReturn(email);
+		given(memberRepository.findByEmail(Email.of(email))).willReturn(Optional.empty());
+
+		// 패널티 여부 확인
+		Member member = Member.builder()
+			.email(Email.of(email))
+			.name(name)
+			.isPenalty(false)
+			.build();
+
+		given(memberRepository.findByEmail(Email.of(email))).willReturn(Optional.of(member));
+
+		Reservation duplicatedReservation = mock(Reservation.class);
+		given(duplicatedReservation.getStatus()).willReturn(ReservationStatus.RESERVED); // 진행 중인 예약
+		given(reservationRepository.findLatestReservationByUserEmail(email))
+			.willReturn(Optional.of(duplicatedReservation));
+
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () ->
+			reservationService.createIndividualReservation(token, request)
+		);
+
+		assertThat(ex.getMessage()).isEqualTo("현재 예약이 진행 중이므로 새로운 예약을 생성할 수 없습니다.");
+		verify(reservationRepository, never()).save(any());
+	}
+
+	void 시간_고정_셋업(int hour, int minute) {
+		LocalDateTime fixedNow = LocalDateTime.of(2025, 3, 22, hour, minute);
+		given(clock.instant()).willReturn(fixedNow.atZone(ZoneId.systemDefault()).toInstant());
+		given(clock.getZone()).willReturn(ZoneId.systemDefault());
+	}
+
+	void 스케줄_설정(Schedule schedule, Long scheduleId, ScheduleSlotStatus scheduleSlotStatus, RoomType roomType, int hour, int minute) {
+		given(schedule.getScheduleDate()).willReturn(LocalDate.of(2025, 3, 22));
+		given(schedule.getStartTime()).willReturn(LocalTime.of(hour, minute));
+		given(schedule.isAvailable()).willReturn(true);
+		given(schedule.isCurrentResLessThanCapacity()).willReturn(true);
+		given(schedule.getStatus()).willReturn(scheduleSlotStatus);
+		lenient().when(schedule.getRoomType()).thenReturn(roomType);
+		given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+	}
+
+	void 스케줄_인원_제한_설정(Schedule schedule, int capacity, int curResCnt) {
+		lenient().when(schedule.getRoomNumber()).thenReturn("305-1");
+		given(schedule.getCapacity()).willReturn(capacity);
+		given(schedule.getCurrentRes()).willReturn(curResCnt);
+	}
+
+	void 예약자_패널티_설정(boolean isPenalty) {
+		given(tokenService.extractEmailFromAccessToken(token)).willReturn(email);
+
+		Member member = Member.builder()
+			.email(Email.of(email))
+			.name("홍길동")
+			.isPenalty(isPenalty)
+			.build();
+
+		given(memberRepository.findByEmail(Email.of(email))).willReturn(Optional.of(member));
+	}
+
+	void QrCode_생성() {
+		given(reservationRepository.save(any())).willAnswer(invocation -> {
+			Reservation reservation = invocation.getArgument(0);
+			reservation.setId(123L);
+			return reservation;
+		});
+
+		given(qrCodeUtil.generateQRCode(eq(email), anyString())).willReturn("fake-qrcode");
+	}
+}
+

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -108,8 +108,8 @@ class IndividualReservationTest {
 	 *   - 스케줄 정보가 저장되며, QR 코드 생성 및 저장됨
 	 *   - 예외 없이 정상적으로 개인 예약 생성 완료
 	 */
-	@DisplayName("정상적으로 스케줄을 1시간 예약 성공")
 	@Test
+	@DisplayName("정상적으로 스케줄을 1시간 예약 성공")
 	void 개인_예약_1시간_성공() {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
@@ -162,8 +162,8 @@ class IndividualReservationTest {
 	 *   - "Success" 반환
 	 *   - 예약 성공 및 관련 데이터 저장 완료
 	 */
-	@DisplayName("정상적으로 스케줄을 2시간 예약 성공")
 	@Test
+	@DisplayName("정상적으로 스케줄을 2시간 예약 성공")
 	void 개인_예약_2시간_성공() {
 		// given
 		Long secondSchuduleId = 2L;
@@ -260,8 +260,8 @@ class IndividualReservationTest {
 	 * ✅ 기대 결과:
 	 *   - 예외 발생 및 저장 로직 미호출
 	 */
-	@DisplayName("사용 불가능한 스케줄로 예약 시도는 예외 발생")
 	@Test
+	@DisplayName("사용 불가능한 스케줄로 예약 시도는 예외 발생")
 	void 사용_불가능한_스케줄로_예약_시도는_예외_발생() {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
@@ -304,8 +304,8 @@ class IndividualReservationTest {
 	 * ✅ 기대 결과:
 	 *   - 예외 발생 ("해당 방은 단체예약 전용입니다.")
 	 */
-	@DisplayName("단체전용방 예약 시도는 예외 발생")
 	@Test
+	@DisplayName("단체전용방 예약 시도는 예외 발생")
 	void 단체전용방_예약_시도는_예외_발생() {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
@@ -346,8 +346,8 @@ class IndividualReservationTest {
 	 * ✅ 기대 결과:
 	 *   - 예외 메시지: "예약자 이메일이 존재하지 않습니다: ... "
 	 */
-	@DisplayName("존재하지 않는 회원의 예약 요청은 예외 발생")
 	@Test
+	@DisplayName("존재하지 않는 회원의 예약 요청은 예외 발생")
 	void 존재하지_않는_회원의_예약_요청은_예외_발생() {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
@@ -391,8 +391,8 @@ class IndividualReservationTest {
 	 * ✅ 기대 결과:
 	 *   - 예외 발생 및 저장 미수행
 	 */
-	@DisplayName("패널티를 받은 회원의 예약 요청은 예외 발생")
 	@Test
+	@DisplayName("패널티를 받은 회원의 예약 요청은 예외 발생")
 	void 패널티를_받은_회원의_예약_요청은_예외_발생() {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(
@@ -435,8 +435,8 @@ class IndividualReservationTest {
 	 * ✅ 기대 결과:
 	 *   - 예외 발생 및 중복 예약 방지
 	 */
-	@DisplayName("예약이 중복된다면 에러 발생")
 	@Test
+	@DisplayName("예약이 중복된다면 에러 발생")
 	void 예약이_중복된다면_에러_발생() {
 		// given
 		CreateReservationRequest request = new CreateReservationRequest(

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/ReservationCancelTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/ReservationCancelTest.java
@@ -18,6 +18,7 @@ import com.ice.studyroom.domain.reservation.presentation.dto.response.CancelRese
 import com.ice.studyroom.global.exception.BusinessException;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -100,6 +101,7 @@ class ReservationCancelTest {
 	 *   - 패널티 없음, 예외 없음
 	 */
 	@Test
+	@DisplayName("입실 1시간 취소 성공")
 	void 예약_1시간_취소_성공() {
 		// given
 		기본_예약_정보_셋업(token, reservationId, userEmail);
@@ -149,6 +151,7 @@ class ReservationCancelTest {
 	 *   - 패널티 없음, 예외 없음
 	 */
 	@Test
+	@DisplayName("예약 2시간 취소 성공")
 	void 예약_2시간_취소_성공() {
 		기본_예약_정보_셋업(token, reservationId, userEmail);
 		시간_고정_셋업(12, 30);
@@ -192,6 +195,7 @@ class ReservationCancelTest {
 	 *   - 시스템이 사용자 권한을 정확히 체크하고, 타인의 예약 변경을 방지함을 보장
 	 */
 	@Test
+	@DisplayName("본인 예약이 아닐 경우 예외")
 	void 본인_예약이_아닐_경우_예외() {
 		given(tokenService.extractEmailFromAccessToken(token)).willReturn("wrong@example.com");
 		given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
@@ -236,6 +240,7 @@ class ReservationCancelTest {
 	 *   - 실제 서비스에서도 해당 시간 조건이 정확히 반영됨을 확인 가능
 	 */
 	@Test
+	@DisplayName("입실까지 1시간보다 적게 남았으면 패널티 부여")
 	void 입실까지_1시간보다_적게_남았으면_패널티_부여() {
 		기본_예약_정보_셋업(token, reservationId, userEmail);
 		시간_고정_셋업(12, 30);
@@ -285,6 +290,7 @@ class ReservationCancelTest {
 	 *   - 실제 서비스에서도 해당 시간 조건이 정확히 반영됨을 확인 가능
 	 */
 	@Test
+	@DisplayName("경계값 테스트 입실까지 정확히 60분 남았을 때 취소하면 패널티 부여")
 	void 경계값_테스트_입실까지_정확히_60분_남았을_때_취소하면_패널티_부여() {
 		기본_예약_정보_셋업(token, reservationId, userEmail);
 		시간_고정_셋업(12, 0);
@@ -329,6 +335,7 @@ class ReservationCancelTest {
 	 *   - 내부 로직 (상태 변경, 패널티, 스케줄 등)은 전혀 실행되지 않음
 	 */
 	@Test
+	@DisplayName("예약이 존재하지 않을 경우 예외")
 	void 예약이_존재하지_않을_경우_예외() {
 		given(reservationRepository.findById(reservationId)).willReturn(Optional.empty());
 
@@ -370,6 +377,7 @@ class ReservationCancelTest {
 	 *   - 비즈니스 정책이 정확하게 적용되며, 시스템 안정성 확보
 	 */
 	@Test
+	@DisplayName("입실 시간 이후 취소는 불가능 하다는 예외 발생")
 	void 입실_시간_이후_취소는_불가능_하다는_예외_발생() {
 		시간_고정_셋업(13, 30);
 		기본_예약_정보_셋업(token, reservationId, userEmail);


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능


## 변경 사항

- 개인 예약과 관련된 테스트 코드 작성

## 관련 이슈

- #417 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세내용
### 테스트 코드 설계 기준

- 비즈니스 로직에 강결합 되어있는 로직은 느슨하게 수정
    - 테스트를 하기 위해 의존성 주입하기 어려운 코드가 존재합니다.
    - 따라서 필요에 따라 결합을 느슨하게 만들기 위해 비즈니스 로직을 수정하고자 합니다.
- 단위 테스트를 최대한 많이 생성하여 테스트에 소요되는 시간 최소화
    - 통합테스트에서는 단위테스트에 비해 많은 시간이 소요되기에 단위 테스트를 많이 생성해서 소요시간을 줄이고자 합니다.
- 다른 개발자가 보더라도 테스트 코드의 이유와 테스트 목표를 명확하게 명시
    - 작성된 테스트 코드는 다른 개발자에게 비즈니스 로직의 목표를 제시해야합니다. 테스트 코드의 존재 이유를 다른 개발자에게 설득할 수 있어야합니다. 이를 위해 주석 추가와 함수명 한글 작성을 통해서 해결하고자 합니다.
- 경계값/예외 상황 테스트 포함
    - 경계 값은 예외 케이스가 많이 발생할 확률이 큽니다. 저희 프로젝트는 시간에 따른 패널티 여부와 예약 성공 여부를 판별하기 때문에 시스템 정책에 맞는 비즈니스 로직이 수행되는지 확인해야합니다.
- 테스트 커버리지보다 "테스트 품질"을 우선
    - 테스트 작성을 무의미한게 양산하게 된다면 테스트 코드의 가독성과 유지보수 또한 불편해집니다.
    - 핵심 기능만을 간추려서 테스트 코드를 작성하려합니다.

### 개인 예약 생성 성공

- 정상적으로 스케줄을 예약 1시간 & 2시간

### 개인 예약 생성 실패

- 시간이 만료된 스케줄을 예약 1시간 & 2시간
- 잘못된 계정으로 예약을 시도한 경우
- 단체예약 전용 방을 개인 예약 시도하는 경우
- 예약 가능한 횟수가 오버부킹되는 경우
- 패널티 상태에서 예약하는 경우

### 테스트 결과
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/140459f7-402d-45cc-a671-af3432e61800" />

### JPA 개선
```
public class ReservationService {
    // .. 코드 생략

    private List<Schedule> findSchedules(Long[] scheduleIds) {
    return Arrays.stream(scheduleIds)
	    .map(id -> scheduleRepository.findById(id)
		    .filter(schedule -> schedule.getStatus() == ScheduleSlotStatus.AVAILABLE) // AVAILABLE 상태 체크
		    .orElseThrow(() -> new BusinessException(StatusCode.NOT_FOUND, "존재하지 않거나 사용 불가능한 스케줄입니다.")))
	    .collect(Collectors.toList());
	    }
}
```
map에 따라서 단일 쿼리가 Long[] scheduleId 배열의 원소 개수만큼 발생하고 있음  
이것을 SELECT FROM WHERE IN 문으로 한번에 가져오는 SQL로 개선

```
public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
        // .. 코드 생략
	List<Schedule> findAllByIdIn(List<Long> ids);
}
```
JPA 메서드 생성
## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
