### PR TITLE
[BE-#425] 예약 API, 패널티 API에 삭제될 컬럼에 대한 종속성 삭제 및 개선

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
@@ -70,7 +70,7 @@ public class PenaltyUpdateScheduler {
 			if (reservation.getStatus() == ReservationStatus.RESERVED
 				&& reservation.checkAttendanceStatus(now) == ReservationStatus.NO_SHOW) {
 				reservation.markStatus(ReservationStatus.NO_SHOW);
-				Member member = memberDomainService.getMemberByEmail(reservation.getUserEmail());
+				Member member = reservation.getMember();
 				penaltyService.assignPenalty(member, reservation.getId(), PenaltyReasonType.NO_SHOW);
 				log.info("해당 유저가 노쇼로 인해 7일 패널티가 부여되었습니다. 이름 : {} 학번 : {}", member.getName(), member.getStudentNum());
 			}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/entity/Reservation.java
@@ -52,12 +52,6 @@ public class Reservation extends BaseTimeEntity {
 	@Column(name = "second_schedule_id")
 	private Long secondScheduleId;
 
-	@Column(name = "user_email", nullable = false)
-	private String userEmail;
-
-	@Column(name = "user_name", nullable = false)
-	private String userName;
-
 	@Column(name = "schedule_date", nullable = false)
 	private LocalDate scheduleDate;
 
@@ -140,8 +134,6 @@ public class Reservation extends BaseTimeEntity {
 			.firstScheduleId(firstSchedule.getId())
 			.secondScheduleId(secondSchedule != null ? secondSchedule.getId() : null)
 			.member(member)
-			.userEmail(email)
-			.userName(userName)
 			.scheduleDate(firstSchedule.getScheduleDate())
 			.roomNumber(firstSchedule.getRoomNumber())
 			.startTime(firstSchedule.getStartTime())

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/infrastructure/persistence/ReservationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
@@ -22,6 +23,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
 	List<Reservation> findByFirstScheduleId(Long firstScheduleId);
 
-	@Query("SELECT r FROM Reservation r WHERE r.userEmail = :email ORDER BY r.createdAt DESC LIMIT 1")
-	Optional<Reservation> findLatestReservationByUserEmail(@Param("email") String email);
+	// @Query("SELECT r FROM Reservation r WHERE r.userEmail = :email ORDER BY r.createdAt DESC LIMIT 1")
+	// Optional<Reservation> findLatestReservationByUserEmail(@Param("email") String email);
+	//
+
+	@Query("SELECT r FROM Reservation r WHERE r.member.email = :email ORDER BY r.createdAt DESC LIMIT 1")
+	Optional<Reservation> findLatestReservationByMemberEmail(@Param("email") Email email);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/scheduler/ReservationUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/scheduler/ReservationUpdateScheduler.java
@@ -1,5 +1,6 @@
 package com.ice.studyroom.domain.reservation.scheduler;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -22,12 +23,13 @@ import lombok.extern.slf4j.Slf4j;
 public class ReservationUpdateScheduler {
 
 	private final ReservationRepository reservationRepository;
+	private final Clock clock;
 
 	@Transactional
 	@Scheduled(cron = "0 1 10-23 * * 1-5")
 	public void updateCompleteReservations(){
 
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime now = LocalDateTime.now(clock);
 		LocalDate todayDate = now.toLocalDate();
 		LocalTime todayTime = now.toLocalTime();
 
@@ -37,8 +39,7 @@ public class ReservationUpdateScheduler {
 			if(reservation.getStatus() == ReservationStatus.ENTRANCE || reservation.getEndTime().isBefore(todayTime)){
 				reservation.markStatus(ReservationStatus.COMPLETED);
 			}
-			log.info("예약이 종료되었습니다.: {} (ID: {}) at {}", reservation.getUserEmail(), reservation.getId(), LocalDateTime.now());
+			log.info("예약이 종료되었습니다.: {} (ID: {}) at {}", reservation.getMember().getName(), reservation.getId(), LocalDateTime.now());
 		});
 	}
-
 }

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -454,7 +454,7 @@ class IndividualReservationTest {
 
 		Reservation duplicatedReservation = mock(Reservation.class);
 		given(duplicatedReservation.getStatus()).willReturn(ReservationStatus.RESERVED); // 진행 중인 예약
-		given(reservationRepository.findLatestReservationByUserEmail(email))
+		given(reservationRepository.findLatestReservationByMemberEmail(email))
 			.willReturn(Optional.of(duplicatedReservation));
 
 		// when & then

--- a/backend/src/test/java/com/ice/studyroom/helper/ReservationTestHelper.java
+++ b/backend/src/test/java/com/ice/studyroom/helper/ReservationTestHelper.java
@@ -15,8 +15,6 @@ public class ReservationTestHelper {
 			.id(1L)
 			.firstScheduleId(100L)
 			.secondScheduleId(200L)
-			.userEmail("test@example.com")
-			.userName("테스트 유저")
 			.scheduleDate(LocalDate.now())
 			.roomNumber("A101")
 			.startTime(startTime)


### PR DESCRIPTION
## PR 종류

- [x] 리팩토링


## 변경 사항

- Reservation 테이블의 userName, userEmali 컬럼 삭제 후 적용

## 관련 이슈

- #425 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
Reservation Entity의 userName, userEmail 제거 후 완전한 member 사용으로 수정해주었습니다.  
정상적으로 테스트 코드를 통과했으며, 비즈니스 로직 또한 QA도 정상적으로 돌아가는 것을 확인했습니다.
<img width="1445" alt="image" src="https://github.com/user-attachments/assets/15e1c896-0237-4b6f-b092-355119743122" />


## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
