### PR TITLE
[BE-#427] 지연로딩에 따른 UserRole 직렬화 실패 오류 수정

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.global.entity.BaseTimeEntity;
 
@@ -54,6 +55,7 @@ public class Member extends BaseTimeEntity {
 		joinColumns = @JoinColumn(name = "user_id")
 	)
 	@Column(name = "role", nullable = false)
+	@JsonIgnore
 	private List<String> roles = new ArrayList<>();
 
 	@Column(name = "is_penalty", nullable = false)

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -454,7 +454,7 @@ class IndividualReservationTest {
 
 		Reservation duplicatedReservation = mock(Reservation.class);
 		given(duplicatedReservation.getStatus()).willReturn(ReservationStatus.RESERVED); // 진행 중인 예약
-		given(reservationRepository.findLatestReservationByMemberEmail(email))
+		given(reservationRepository.findLatestReservationByMemberEmail(Email.of(email)))
 			.willReturn(Optional.of(duplicatedReservation));
 
 		// when & then


### PR DESCRIPTION
## PR 종류
- [x] 버그 수정

## 변경 사항

- 예약 조회 API 호출 시 fetch가 되지 않는 오류 확인


## 관련 이슈

- #427 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
<img width="631" alt="image" src="https://github.com/user-attachments/assets/18bd28bd-d576-4561-a700-38bb68feb608" />

```
failed to lazily initialize a collection of role: Member.roles
could not initialize proxy - no Session
```
위의 에러 로그 발생  

이는 Member 엔티티에 외래키인 role 컬럼의 지연로딩이 JPA 세션이 종료되었는데도 직렬화를 시도하는데서 발생한 오류임을 확인
따라서

```
	@ElementCollection(fetch = FetchType.LAZY)
	@CollectionTable(
		name = "user_roles",
		joinColumns = @JoinColumn(name = "user_id")
	)
	@Column(name = "role", nullable = false)
	@JsonIgnore
	private List<String> roles = new ArrayList<>();
```
위와 같이 JsonIgnore로 처리해주어 직렬화가 무시되게 처리  
JWT에서 이미 userRole을 추출하기 때문에 직렬화 무시 처리해도 비즈니스 로직은 정상적으로 작동합니다.

## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
