### PR TITLE
[FE-#433] QRcode에 data값만 전달 및 이중 인코딩 제거

### DIFF
--- a/frontend/src/pages/Mainpage/components/QRCodeFetcher.jsx
+++ b/frontend/src/pages/Mainpage/components/QRCodeFetcher.jsx
@@ -43,14 +43,14 @@ const useQRCodeFetcher = (resId) => {
         throw new Error(`서버 오류: ${response.status}`);
       }
 
-      const data = await response.text();
-      setQrCode(data);
+      const json = await response.json();
+      setQrCode(json.data);
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
-  }, [resId, qrCode]);
+  }, [resId, qrCode])
 
   const sendQRCodeToServer = useCallback(async () => {
     if (!qrCode) {
@@ -71,7 +71,7 @@ const useQRCodeFetcher = (resId) => {
           Authorization: `Bearer ${accessToken}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ qrCode: qrBase64 }),
+        body: JSON.stringify({ qrCode }),
       });
 
       if (response.status === 401) {

--- a/frontend/src/pages/ReservationStatus/MyReservationStatus.jsx
+++ b/frontend/src/pages/ReservationStatus/MyReservationStatus.jsx
@@ -197,11 +197,11 @@ const MyReservationStatus = () => {
               <p className="text-sm text-red-500">{qrError}</p>
             ) : qrCode ? (
               <>
-              <QRCodeCanvas 
-                value={qrCode} 
-                size={256} 
-                level={"H"} 
-                includeMargin={true} 
+              <img
+                src={`data:image/png;base64,${qrCode}`}
+                alt="QR 코드"
+                width={256}
+                height={256}
               />
               </>
             ) : (


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- QR코드 data값만 저장
- QrcodeCanvas 대신 img 사용하여 중복 인코딩 방지
- 
## 관련 이슈

- #433 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷

![image](https://github.com/user-attachments/assets/77190f3a-b8c1-4e41-9041-defdb00faffb)
