### PR TITLE
[BE-#434] 입실 API 요청 값을 QR 코드가 아닌 QR 토큰 전달로 수정

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -145,11 +145,10 @@ public class ReservationService {
 
 	@Transactional
 	public QrEntranceResponse qrEntrance(QrEntranceRequest request) {
-		// 이미지를 저장.
-		String qrCode = request.qrCode();
+		// 클라이언트로부터 전달된 토큰 저장
+		String token = request.qrToken();
 
 		// 토큰으로 예약 ID 조회
-		String token = qrCodeUtil.decodeQRCodeImage(qrCode);
 		Long reservationId = qrCodeService.getReservationIdByToken(token);
 		if (reservationId == null) {
 			throw new BusinessException(StatusCode.BAD_REQUEST, "만료되었거나 유효하지 않은 QR 코드입니다.");

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/QrEntranceRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/request/QrEntranceRequest.java
@@ -3,7 +3,7 @@ package com.ice.studyroom.domain.reservation.presentation.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record QrEntranceRequest(
-	@NotBlank(message = "QR Code는 필수입니다.")
-	String qrCode
+	@NotBlank(message = "QR Token은 필수입니다.")
+	String qrToken
 ) {
 }


### PR DESCRIPTION
## PR 종류

- [x] 리팩토링


## 변경 사항

- QR 토큰을 클라이언트로부터 전달받는 로직으로 변경됨애 따라 코드 수정

## 관련 이슈

- #434  

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세내용
```
public class ReservationService {
        // .. 코드 생략

	@Transactional
	public QrEntranceResponse qrEntrance(QrEntranceRequest request) {
		// 클라이언트로부터 전달된 토큰 저장
		String token = request.qrToken();

		// 토큰으로 예약 ID 조회
		Long reservationId = qrCodeService.getReservationIdByToken(token);
                 if (reservationId == null) {
			throw new BusinessException(StatusCode.BAD_REQUEST, "만료되었거나 유효하지 않은 QR 코드입니다.");
		}

                 // .. 코드 생략
         }
}
```
입실 API에 전달되는 클라이언트 DTO의 값이 이미지가 아닌 토큰으로 수정되었기에 토큰으로 변경해주었습니다.

## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
