### PR TITLE
[BE-#448,#449] Transactional 점검, 그룹 예약 연장 로직 보완

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
@@ -25,11 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class AdminService {
 
 	private final RoomTimeSlotRepository roomTimeSlotRepository;
@@ -38,6 +36,7 @@ public class AdminService {
 	private final MemberRepository memberRepository;
 	private final PenaltyService penaltyService;
 
+	@Transactional
 	public String adminOccupyRooms(AdminOccupyRequest request) {
 		//당일 선점일 경우, 스케줄에도 반영
 		if(request.dayOfWeek() == DayOfWeekStatus.valueOf(LocalDate.now().getDayOfWeek().name())){
@@ -69,6 +68,7 @@ public class AdminService {
 		return "관리자가 선택한 시간대를 선점했습니다.";
 	}
 
+	@Transactional
 	public String adminReleaseRooms(AdminReleaseRequest request) {
 		//당일 선점 해지일 경우, 스케줄에도 반영
 		if(request.dayOfWeek() == DayOfWeekStatus.valueOf(LocalDate.now().getDayOfWeek().name())){

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
@@ -1,6 +1,5 @@
 package com.ice.studyroom.domain.membership.application;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.security.authentication.AuthenticationManager;

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
@@ -30,7 +30,6 @@ import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyReposi
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class MembershipService {
 	private final MemberDomainService memberDomainService;
@@ -40,11 +39,13 @@ public class MembershipService {
 	private final EmailVerificationService emailVerificationService;
 	private final PenaltyRepository penaltyRepository;
 
+	@Transactional
 	public MemberResponse createMember(MemberCreateRequest request) {
 		memberDomainService.registerMember(request);
 		return MemberResponse.of("success");
 	}
 
+	@Transactional
 	public JwtToken login(MemberLoginRequest request) {
 
 		Member member = memberDomainService.getMemberByEmailForLogin(request.email());
@@ -60,12 +61,14 @@ public class MembershipService {
 		return jwtToken;
 	}
 
+	@Transactional
 	public JwtToken refresh(String authorizationHeader, String refreshToken) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
 		String accessToken = authorizationHeader.replace("Bearer ", "");
 		return tokenService.rotateToken(email, accessToken, refreshToken);
 	}
 
+	@Transactional
 	public MemberResponse logout(String authorizationHeader, String refreshToken) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
 
@@ -74,6 +77,7 @@ public class MembershipService {
 		return MemberResponse.of("정상적으로 로그아웃 되었습니다.");
 	}
 
+	@Transactional
 	public String updatePassword(String authorizationHeader, UpdatePasswordRequest request) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
 		Member member = memberDomainService.getMemberByEmail(email);

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/scheduler/PenaltyUpdateScheduler.java
@@ -32,7 +32,6 @@ public class PenaltyUpdateScheduler {
 	private final PenaltyRepository penaltyRepository;
 	private final ReservationRepository reservationRepository;
 	private final PenaltyService penaltyService;
-	private final MemberDomainService memberDomainService;
 
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *") // 매일 00:00에 실행

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -50,7 +50,6 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ReservationService {
 
 	private final QRCodeUtil qrCodeUtil;
@@ -118,6 +117,7 @@ public class ReservationService {
 			.collect(Collectors.toList());
 	}
 
+	@Transactional
 	public String getMyReservationQrCode(Long reservationId, String authorizationHeader) {
 		String reservationOwnerEmail = tokenService.extractEmailFromAccessToken(authorizationHeader);
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -416,17 +416,18 @@ public class ReservationService {
 		}
 
 		if (nextSchedule.getRoomType() == RoomType.GROUP) {
-			// 그룹 예약 이기에 같은 시간대의 예약 레코드를 모두 가져온다(참여자 검증 필요). memeber 1차 캐시되며 이 값을 사용할 예정
+			// 그룹 예약 이기에 같은 시간대의 예약 레코드를 모두 가져온다(참여자 검증 필요).
 			List<Reservation> reservations = reservationRepository.findByFirstScheduleId(reservation.getFirstScheduleId());
 
 			// 패널티를 부여받고 있는 참여자가 존재할 경우 예약 연장 진행 불가
 			for (Reservation res : reservations) {
+				//취소된 예약의 건에 대해서는 제외
+				if (res.getStatus() == ReservationStatus.CANCELLED) continue;
+
 				if (res.getMember().isPenalty()) {
 					throw new BusinessException(StatusCode.FORBIDDEN, "패널티가 있는 멤버로 인해 연장이 불가능합니다.");
 				}
-			}
 
-			for (Reservation res : reservations) {
 				//1명이라도 입실하지 않은 경우
 				if (!res.isEntered()){
 					//지각 입실은 앞서 패널티 체킹으로 연장 불가 처리
@@ -435,6 +436,7 @@ public class ReservationService {
 			}
 
 			for (Reservation res : reservations) {
+				if (res.getStatus() == ReservationStatus.CANCELLED) continue;
 				res.extendReservation(nextSchedule.getId(), nextSchedule.getEndTime());
 				nextSchedule.reserve();
 			}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/scheduler/ReservationUpdateScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/scheduler/ReservationUpdateScheduler.java
@@ -36,7 +36,7 @@ public class ReservationUpdateScheduler {
 		log.info("Processing update reservation status to complete for date: {} and time: {}", todayDate, todayTime);
 
 		reservationRepository.findByScheduleDateAndEndTime(todayDate, todayTime.minusMinutes(2)).forEach(reservation -> {
-			if(reservation.getStatus() == ReservationStatus.ENTRANCE || reservation.getEndTime().isBefore(todayTime)){
+			if(reservation.getStatus() == ReservationStatus.ENTRANCE){
 				reservation.markStatus(ReservationStatus.COMPLETED);
 			}
 			log.info("예약이 종료되었습니다.: {} (ID: {}) at {}", reservation.getMember().getName(), reservation.getId(), LocalDateTime.now());

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -225,7 +225,7 @@ class IndividualReservationTest {
 			reservationService.createIndividualReservation(token, request)
 		);
 
-		assertThat(ex.getMessage()).isEqualTo("예약이 불가능합니다.");
+		assertThat(ex.getMessage()).isEqualTo("예약이 불가능합니다. 스케줄이 유효하지 않거나 이미 예약이 완료되었습니다.");
 		verify(reservationRepository, never()).save(any());
 	}
 
@@ -267,7 +267,7 @@ class IndividualReservationTest {
 			reservationService.createIndividualReservation(token, request)
 		);
 
-		assertThat(ex.getMessage()).isEqualTo("예약이 불가능합니다.");
+		assertThat(ex.getMessage()).isEqualTo("예약이 불가능합니다. 스케줄이 유효하지 않거나 이미 예약이 완료되었습니다.");
 
 		verify(reservationRepository, never()).save(any());
 	}


### PR DESCRIPTION
## PR 종류
사용하지 않는 PR 종류는 삭제해주세요  
- [x] 기능 개선
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

- @Transactional 점검
- 정상 출석된 예약에 대해서만 `COMPLETED` 처리
- 그룹 예약 연장 시, 취소된 예약자는 연장 로직 검증에서 제외하도록 설정

## 관련 이슈

#448 #449 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

### 기존 그룹 연장 로직의 문제점
그룹 예약 단위로 연장 처리 시, 사전에 예약을 취소한 유저에 영향을 받는 상황이었습니다.
사전에 예약을 취소한 유저는 당연히 입실이 불가능하고, 더불어 패널티가 있을 수도 있습니다.

<img width="826" alt="image" src="https://github.com/user-attachments/assets/1e7b25f1-d018-4a63-9603-7fe361acffb3" />

해당 유저에 의해 연장이 불가능하지 않도록 로직을 개선했습니다.

### @Transaction 적용 기준

https://www.notion.so/Transactional-1ca7d6c84c71802b8fd5d5662a0aef7d

