### PR TITLE
[BE-#455] 최근 예약 기록 확인 API 응답에 시작시간, 종료시간 추가

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetMostRecentReservationResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/dto/response/GetMostRecentReservationResponse.java
@@ -1,6 +1,7 @@
 package com.ice.studyroom.domain.reservation.presentation.dto.response;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
@@ -8,13 +9,15 @@ import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
 public record GetMostRecentReservationResponse(
 	LocalDate scheduleDate,
 	String roomNumber,
-	ReservationStatus status
+	LocalTime startTime,
+	LocalTime endTime
 ) {
 	public static GetMostRecentReservationResponse from(Reservation reservation) {
 		return new GetMostRecentReservationResponse(
 			reservation.getScheduleDate(),
 			reservation.getRoomNumber(),
-			reservation.getStatus()
+			reservation.getStartTime(),
+			reservation.getEndTime()
 		);
 	}
 }


### PR DESCRIPTION
## PR 종류
- [x] 리팩토링

## 변경 사항

- 최근 예약 기록 확인 API 응답에 시작시간, 종료시간 추가

## 관련 이슈

- #455 
## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
```java
public record GetMostRecentReservationResponse(
	LocalDate scheduleDate,
	String roomNumber,
	LocalTime startTime,
	LocalTime endTime
) {
	public static GetMostRecentReservationResponse from(Reservation reservation) {
		return new GetMostRecentReservationResponse(
			reservation.getScheduleDate(),
			reservation.getRoomNumber(),
			reservation.getStartTime(),
			reservation.getEndTime()
		);
	}
}
```
예약 시작 시간, 종료 시간을 추가해주었습니다.
![image](https://github.com/user-attachments/assets/e42c4a44-ab44-4da5-9060-59b540c3baa8)

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
