### PR TITLE
[BE-#478] 서비스 로깅 메시지 통일 및 유틸리티 적용

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
@@ -1,6 +1,7 @@
 package com.ice.studyroom.domain.admin.application;
 
 import com.ice.studyroom.domain.admin.domain.type.DayOfWeekStatus;
+import com.ice.studyroom.domain.admin.domain.util.AdminLogUtil;
 import com.ice.studyroom.domain.admin.presentation.dto.request.AdminDelPenaltyRequest;
 import com.ice.studyroom.domain.admin.presentation.dto.request.AdminOccupyRequest;
 import com.ice.studyroom.domain.admin.presentation.dto.request.AdminReleaseRequest;
@@ -42,20 +43,20 @@ public class AdminService {
 
 	@Transactional
 	public String adminOccupyRooms(AdminOccupyRequest request) {
-		log.info("관리자 선점 요청 - roomTimeSlotIds: {}, 요일: {}", request.roomTimeSlotId(), request.dayOfWeek());
+		AdminLogUtil.log("관리자 선점 요청", "roomTimeSlotIds: " + request.roomTimeSlotId(), "요일: " + request.dayOfWeek());
 		//당일 선점일 경우, 스케줄에도 반영
 		if(request.dayOfWeek() == DayOfWeekStatus.valueOf(LocalDate.now().getDayOfWeek().name())){
 			List<Schedule> todaySchedules = scheduleRepository.findByScheduleDateAndRoomTimeSlotIdIn(LocalDate.now(),
 				request.roomTimeSlotId());
 
 			if(todaySchedules.isEmpty()){
-				log.warn("선점 실패 - 당일 일치 스케줄 없음 - roomTimeSlotIds: {}, date: {}", request.roomTimeSlotId(), LocalDate.now());
+				AdminLogUtil.logWarn("선점 실패 - 당일 일치 스케줄 없음", "roomTimeSlotIds: " + request.roomTimeSlotId(), "date: " + LocalDate.now());
 				throw new BusinessException(StatusCode.NOT_FOUND, "해당 RoomTimeSlot ID에 일치하는 Schedule이 존재하지 않습니다.");
 			}
 
 			for (Schedule schedule : todaySchedules) {
 				if(schedule.getStatus() == ScheduleSlotStatus.RESERVED){
-					log.warn("선점 실패 - 예약된 스케줄 존재 - scheduleId: {}", schedule.getId());
+					AdminLogUtil.logWarn("선점 실패 - 예약된 스케줄 존재", "scheduleId: " + schedule.getId());
 					throw new BusinessException(StatusCode.BAD_REQUEST, "예약이 이루어진 스케줄에 대해서는 선점이 불가능합니다.");
 				}
 				schedule.updateStatus(ScheduleSlotStatus.UNAVAILABLE);
@@ -65,33 +66,33 @@ public class AdminService {
 		List<RoomTimeSlot> roomTimeSlots = roomTimeSlotRepository.findAllById(request.roomTimeSlotId());
 
 		if (roomTimeSlots.isEmpty()) {
-			log.warn("선점 실패 - 유효하지 않은 roomTimeSlot ID - 요청 ID 목록: {}", request.roomTimeSlotId());
+			AdminLogUtil.logWarn("선점 실패 - 유효하지 않은 roomTimeSlot ID", "요청 ID 목록: " + request.roomTimeSlotId());
 			throw new BusinessException(StatusCode.NOT_FOUND, "해당 ID에 일치하는 RoomTimeSlot이 존재하지 않습니다.");
 		}
 
 		for (RoomTimeSlot roomTimeSlot : roomTimeSlots) {
 			roomTimeSlot.updateStatus(ScheduleSlotStatus.UNAVAILABLE);
 		}
-		log.info("관리자 선점 완료 - 선점된 roomTimeSlot 수: {}", roomTimeSlots.size());
+		AdminLogUtil.log("관리자 선점 완료", "선점된 roomTimeSlot 수: " + roomTimeSlots.size());
 		return "관리자가 선택한 시간대를 선점했습니다.";
 	}
 
 	@Transactional
 	public String adminReleaseRooms(AdminReleaseRequest request) {
-		log.info("관리자 선점 해제 요청 - roomTimeSlotIds: {}, 요일: {}", request.roomTimeSlotId(), request.dayOfWeek());
+		AdminLogUtil.log("관리자 선점 해제 요청", "roomTimeSlotIds: " + request.roomTimeSlotId(), "요일: " + request.dayOfWeek());
 		//당일 선점 해지일 경우, 스케줄에도 반영
 		if(request.dayOfWeek() == DayOfWeekStatus.valueOf(LocalDate.now().getDayOfWeek().name())){
 			List<Schedule> todaySchedules = scheduleRepository.findByScheduleDateAndRoomTimeSlotIdIn(LocalDate.now(),
 				request.roomTimeSlotId());
 
 			if(todaySchedules.isEmpty()){
-				log.warn("선점 해제 실패 - 당일 일치 스케줄 없음 - roomTimeSlotIds: {}, date: {}", request.roomTimeSlotId(), LocalDate.now());
+				AdminLogUtil.logWarn("선점 해제 실패 - 당일 일치 스케줄 없음", "roomTimeSlotIds: " + request.roomTimeSlotId(), "date: " + LocalDate.now());
 				throw new BusinessException(StatusCode.NOT_FOUND, "해당 RoomTimeSlot ID에 일치하는 Schedule이 존재하지 않습니다.");
 			}
 
 			for (Schedule schedule : todaySchedules) {
 				if(schedule.getStatus() == ScheduleSlotStatus.RESERVED){
-					log.warn("선점 해제 실패 - 예약된 스케줄 존재 - scheduleId: {}", schedule.getId());
+					AdminLogUtil.logWarn("선점 해제 실패 - 예약된 스케줄 존재", "scheduleId: " + schedule.getId());
 					throw new BusinessException(StatusCode.BAD_REQUEST, "예약이 이루어진 스케줄에 대해서는 선점 해지가 불가능합니다.");
 				}
 				schedule.updateStatus(ScheduleSlotStatus.AVAILABLE);
@@ -101,14 +102,14 @@ public class AdminService {
 		List<RoomTimeSlot> roomTimeSlots = roomTimeSlotRepository.findAllById(request.roomTimeSlotId());
 
 		if (roomTimeSlots.isEmpty()) {
-			log.warn("선점 해제 실패 - 유효하지 않은 roomTimeSlot ID - 요청 ID 목록: {}", request.roomTimeSlotId());
+			AdminLogUtil.logWarn("선점 해제 실패 - 유효하지 않은 roomTimeSlot ID", "요청 ID 목록: " + request.roomTimeSlotId());
 			throw new BusinessException(StatusCode.NOT_FOUND, "해당 ID에 일치하는 RoomTimeSlot이 존재하지 않습니다.");
 		}
 
 		for (RoomTimeSlot roomTimeSlot : roomTimeSlots) {
 			roomTimeSlot.updateStatus(ScheduleSlotStatus.AVAILABLE);
 		}
-		log.info("관리자 선점 해제 완료 - 해제된 roomTimeSlot 수: {}", roomTimeSlots.size());
+		AdminLogUtil.log("관리자 선점 해제 완료", "해제된 roomTimeSlot 수: " + roomTimeSlots.size());
 		return "관리자가 선택한 시간대의 선점을 해제했습니다.";
 	}
 
@@ -142,44 +143,44 @@ public class AdminService {
 
 	@Transactional
 	public String adminSetPenalty(AdminSetPenaltyRequest request) {
-		log.info("관리자 패널티 부여 요청 - 학번: {}, 종료일시: {}", request.studentNum(), request.penaltyEndAt());
+		AdminLogUtil.log("관리자 패널티 부여 요청", "학번: " + request.studentNum(), "종료일시: " + request.penaltyEndAt());
 		Member member = memberRepository.findByStudentNum(request.studentNum())
 			.orElseThrow(() -> {
-				log.warn("패널티 부여 실패 - 존재하지 않는 학번 - 학번: {}", request.studentNum());
+				AdminLogUtil.logWarn("패널티 부여 실패 - 존재하지 않는 학번", "학번: " + request.studentNum());
 				return new BusinessException(StatusCode.NOT_FOUND, "해당 학번을 가진 회원은 존재하지 않습니다.");
 			});
 
 		if (member.isPenalty()) {
-			log.warn("패널티 부여 실패 - 이미 패널티 상태 - 학번: {}", request.studentNum());
+			AdminLogUtil.logWarn("패널티 부여 실패 - 이미 패널티 상태", "학번: " + request.studentNum());
 			throw new BusinessException(StatusCode.BAD_REQUEST, "이미 패널티가 부여된 회원입니다. 패널티 해제 후 다시 시도해주세요.");
 		}
 
 		if(member.getRoles().contains("ROLE_ADMIN")){
-			log.warn("패널티 부여 실패 - 대상이 ADMIN 계정 - 학번: {}", request.studentNum());
+			AdminLogUtil.logWarn("패널티 부여 실패 - 대상이 ADMIN 계정", "학번: " + request.studentNum());
 			throw new BusinessException(StatusCode.BAD_REQUEST, "ADMIN 계정에는 패널티 설정을 할 수 없습니다.");
 		}
 
 		penaltyService.adminAssignPenalty(member, request.penaltyEndAt());
-		log.info("관리자 패널티 부여 완료 - 학번: {}", request.studentNum());
+		AdminLogUtil.log("패널티 부여 완료", "학번: " + request.studentNum(), "사유: ADMIN");
 		return "패널티 부여가 완료되었습니다.";
 	}
 
 	@Transactional
 	public String adminDelPenalty(AdminDelPenaltyRequest request) {
-		log.info("관리자 패널티 해제 요청 - 학번: {}", request.studentNum());
+		AdminLogUtil.log("관리자 패널티 해제 요청", "학번: " + request.studentNum());
 		Member member = memberRepository.findByStudentNum(request.studentNum())
 			.orElseThrow(() -> {
-				log.warn("패널티 부여 실패 - 존재하지 않는 학번 - 학번: {}", request.studentNum());
+				AdminLogUtil.logWarn("패널티 해제 실패 - 존재하지 않는 학번", "학번: " + request.studentNum());
 				return new BusinessException(StatusCode.NOT_FOUND, "해당 학번을 가진 회원은 존재하지 않습니다.");
 			});
 
 		if (!member.isPenalty()) {
-			log.warn("패널티 해제 실패 - 제재 상태 아님 - 학번: {}", request.studentNum());
+			AdminLogUtil.logWarn("패널티 해제 실패 - 제재 상태 아님", "학번: " + request.studentNum());
 			throw new BusinessException(StatusCode.BAD_REQUEST, "패널티가 부여되지 않은 회원입니다.");
 		}
 
 		penaltyService.adminDeletePenalty(member);
-		log.info("관리자 패널티 해제 완료 - 학번: {}", request.studentNum());
+		AdminLogUtil.log("패널티 해제 완료", "학번: " + request.studentNum());
 		return "패널티 해제가 완료되었습니다.";
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/domain/util/AdminLogUtil.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/domain/util/AdminLogUtil.java
@@ -1,0 +1,17 @@
+package com.ice.studyroom.domain.admin.domain.util;
+
+import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AdminLogUtil {
+
+	public static void log(String message, Object... details) {
+		log.info("[ADMIN] {} - {}", message, Arrays.toString(details));
+	}
+
+	public static void logWarn(String message, Object... details) {
+		log.warn("[ADMIN] {} - {}", message, Arrays.toString(details));
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/application/MembershipService.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ice.studyroom.domain.membership.domain.util.MembershipLogUtil;
 import com.ice.studyroom.global.security.jwt.JwtToken;
 import com.ice.studyroom.domain.identity.domain.application.EmailVerificationService;
 import com.ice.studyroom.global.security.service.TokenService;
@@ -43,14 +44,15 @@ public class MembershipService {
 
 	@Transactional
 	public MemberResponse createMember(MemberCreateRequest request) {
-		log.info("회원가입 요청 수신 - email: {}", request.email());
+		MembershipLogUtil.log("회원가입 요청", "email: " + request.email());
 		memberDomainService.registerMember(request);
+		MembershipLogUtil.log("회원가입 성공", "email: " + request.email());
 		return MemberResponse.of("success");
 	}
 
 	@Transactional
 	public JwtToken login(MemberLoginRequest request) {
-		log.info("로그인 요청 수신 - email: {}", request.email());
+		MembershipLogUtil.log("로그인 요청", "email: " + request.email());
 
 		Member member = memberDomainService.getMemberByEmailForLogin(request.email());
 		memberDomainService.validatePasswordMatch(member, request.password());
@@ -62,24 +64,27 @@ public class MembershipService {
 		JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 		tokenService.saveRefreshToken(request.email(), jwtToken.getRefreshToken());
 
-		log.info("로그인 성공 - email: {}", request.email());
+		MembershipLogUtil.log("로그인 성공", "email: " + request.email());
 		return jwtToken;
 	}
 
 	@Transactional
 	public JwtToken refresh(String authorizationHeader, String refreshToken) {
-		log.info("토큰 리프레시 요청 수신");
+		MembershipLogUtil.log("토큰 리프레시 요청", "Authorization 헤더 존재 여부: " + (authorizationHeader != null));
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
 		String accessToken = authorizationHeader.replace("Bearer ", "");
-		return tokenService.rotateToken(email, accessToken, refreshToken);
+		JwtToken token = tokenService.rotateToken(email, accessToken, refreshToken);
+		MembershipLogUtil.log("토큰 리프레시 성공", "email: " + email);
+		return token;
 	}
 
 	@Transactional
 	public MemberResponse logout(String authorizationHeader, String refreshToken) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
-		log.info("로그아웃 요청 수신 - email: {}", email);
+		MembershipLogUtil.log("로그아웃 요청", "email: " + email);
 
 		tokenService.deleteToken(email, refreshToken);
+		MembershipLogUtil.log("로그아웃 성공", "email: " + email);
 
 		return MemberResponse.of("정상적으로 로그아웃 되었습니다.");
 	}
@@ -87,36 +92,45 @@ public class MembershipService {
 	@Transactional
 	public String updatePassword(String authorizationHeader, UpdatePasswordRequest request) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
-		log.info("비밀번호 변경 요청 수신 - email: {}", email);
-		Member member = memberDomainService.getMemberByEmail(email);
-		memberDomainService.updateMemberPassword(member, request.currentPassword(), request.updatedPassword(),
-			request.updatedPasswordForCheck());
+		MembershipLogUtil.log("비밀번호 변경 요청", "email: " + email);
 
+		Member member = memberDomainService.getMemberByEmail(email);
+		memberDomainService.updateMemberPassword(member, request.currentPassword(), request.updatedPassword(), request.updatedPasswordForCheck());
+
+		MembershipLogUtil.log("비밀번호 변경 성공", "email: " + email);
 		return "비밀번호가 성공적으로 변경되었습니다.";
 	}
 
 	public MemberLookupResponse lookUpMember(String authorizationHeader) {
 		String email = tokenService.extractEmailFromAccessToken(authorizationHeader);
-		log.info("회원 정보 조회 요청 수신 - email: {}", email);
+		MembershipLogUtil.log("회원 정보 조회 요청", "email: " + email);
+
 		String userName = memberDomainService.getUserNameByEmail(Email.of(email));
 		Member member = memberDomainService.getMemberByEmail(email);
 
 		Optional<Penalty> penalty = penaltyRepository.findByMemberIdAndStatus(member.getId(), PenaltyStatus.VALID);
+		MembershipLogUtil.log("회원 정보 조회 성공", "email: " + email);
 
 		return penalty.map(p -> MemberLookupResponse.of(email, userName, p.getReason(), p.getPenaltyEnd()))
 			.orElseGet(() -> MemberLookupResponse.of(email, userName));
 	}
 
 	public MemberEmailResponse sendMail(EmailVerificationRequest request) {
-		log.info("이메일 인증 요청 - email: {}", request.email());
+		MembershipLogUtil.log("이메일 인증 요청", "email: " + request.email());
+
 		memberDomainService.validateEmailUniqueness(Email.of(request.email()));
 		emailVerificationService.sendCodeToEmail(request.email());
+
+		MembershipLogUtil.log("이메일 인증 코드 전송 완료", "email: " + request.email());
 		return MemberEmailResponse.of("인증 메일이 전송되었습니다.");
 	}
 
 	public MemberEmailResponse checkEmailVerification(MemberEmailVerificationRequest request) {
-		log.info("이메일 인증 확인 요청 - email: {}", request.email());
+		MembershipLogUtil.log("이메일 인증 확인 요청", "email: " + request.email());
+
 		emailVerificationService.verifiedCode(request.email(), request.code());
+		MembershipLogUtil.log("이메일 인증 확인 성공", "email: " + request.email());
+
 		return MemberEmailResponse.of("인증이 완료되었습니다.");
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
@@ -119,4 +119,14 @@ public class MemberDomainService {
 		member.changePassword(passwordEncoder.encode(newPassword));
 		memberRepository.save(member);
 	}
+
+	public boolean isMemberPenalty(String email) {
+		Member member = getMemberByEmail(email);
+		return member.isPenalty();
+	}
+
+	public List<Member> getMembersByEmail(List<Email> emails){
+		return memberRepository.findByEmailIn(emails);
+	}
+
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.ice.studyroom.domain.identity.domain.service.VerificationCodeCacheService;
 import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.util.MembershipLogUtil;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
 import com.ice.studyroom.domain.membership.presentation.dto.request.MemberCreateRequest;
@@ -27,11 +28,10 @@ public class MemberDomainService {
 	private final VerificationCodeCacheService verificationCodeCacheService;
 
 	public void registerMember(MemberCreateRequest request) {
-		log.info("회원 등록 도메인 로직 진입 - email: {}", request.email());
+		MembershipLogUtil.log("회원 등록 도메인 로직 진입", "email: " + request.email());
 		validateEmailUniqueness(Email.of(request.email()));
 		checkVerification(request.isAuthenticated());
 		validateVerificationCode(request.email(), request.authenticationCode());
-		//validateStudentNumberUniqueness(request.studentNum());
 
 		Member member = Member.create(
 			Email.of(request.email()),
@@ -46,40 +46,30 @@ public class MemberDomainService {
 
 	public void validateEmailUniqueness(Email email) {
 		if (memberRepository.existsByEmail(email)) {
-			log.warn("회원 등록 실패 - 중복 이메일 - email: {}", email.getValue());
+			MembershipLogUtil.logWarn("회원 등록 실패 - 중복 이메일", "email: " + email.getValue());
 			throw new BusinessException(StatusCode.CONFLICT, "이미 사용 중인 이메일입니다.");
 		}
 	}
 
-	// private void validateStudentNumberUniqueness(String studentNum) {
-	// 	if (memberRepository.existsByStudentNum(studentNum)) {
-	// 		throw new BusinessException(StatusCode.CONFLICT, "이미 사용 중인 학번입니다.");
-	// 	}
-	// }
-
 	public Member getMemberByEmail(String email) {
 		return Optional.ofNullable(memberRepository.getMemberByEmail(Email.of(email)))
 			.orElseThrow(() -> {
-				log.warn("회원 조회 실패 - 존재하지 않는 이메일 - email: {}", email);
+				MembershipLogUtil.logWarn("회원 조회 실패 - 존재하지 않는 이메일", "email: " + email);
 				return new BusinessException(StatusCode.NOT_FOUND, "해당 이메일을 가진 유저는 존재하지 않습니다.");
 			});
-	}
-
-	public List<Member> getMembersByEmail(List<Email> emails){
-		return memberRepository.findByEmailIn(emails);
 	}
 
 	public Member getMemberByEmailForLogin(String email) {
 		return Optional.ofNullable(memberRepository.getMemberByEmail(Email.of(email)))
 			.orElseThrow(() -> {
-				log.warn("로그인 실패 - 존재하지 않는 이메일 - email: {}", email);
+				MembershipLogUtil.logWarn("로그인 실패 - 존재하지 않는 이메일", "email: " + email);
 				return new BusinessException(StatusCode.BAD_REQUEST, "아이디 혹은 비밀번호가 일치하지 않습니다.");
 			});
 	}
 
 	public void validatePasswordMatch(Member member, String password){
 		if(!member.isPasswordValid(password, passwordEncoder)){
-			log.warn("로그인 실패 - 비밀번호 불일치 - email: {}", member.getEmail().getValue());
+			MembershipLogUtil.logWarn("로그인 실패 - 비밀번호 불일치", "email: " + member.getEmail().getValue());
 			throw new BusinessException(StatusCode.BAD_REQUEST, "아이디 혹은 비밀번호가 일치하지 않습니다.");
 		}
 	}
@@ -88,49 +78,45 @@ public class MemberDomainService {
 		return memberRepository.findByEmail(email)
 			.map(Member::getName)
 			.orElseThrow(() -> {
-				log.warn("이름 조회 실패 - 존재하지 않는 이메일 - email: {}", email.getValue());
+				MembershipLogUtil.logWarn("이름 조회 실패 - 존재하지 않는 이메일", "email: " + email.getValue());
 				return new BusinessException(StatusCode.NOT_FOUND, "해당 이메일을 가진 유저는 존재하지 않습니다.");
 			});
 	}
 
 	private void checkVerification(boolean isAuthenticated) {
 		if (!isAuthenticated) {
-			log.warn("회원 등록 실패 - 이메일 인증 안됨");
+			MembershipLogUtil.logWarn("회원 등록 실패 - 이메일 인증 안됨");
 			throw new BusinessException(StatusCode.BAD_REQUEST, "이메일 인증을 진행해주세요.");
 		}
 	}
 
 	private void validateVerificationCode(String email, String authenticationCode) {
 		if (!Objects.equals(verificationCodeCacheService.getVerificationCode(email), authenticationCode)) {
-			log.warn("회원 등록 실패 - 인증 코드 불일치 - email: {}", email);
+			MembershipLogUtil.logWarn("회원 등록 실패 - 인증 코드 불일치", "email: " + email);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "인증 코드가 유효하지 않거나 만료되었습니다.");
 		}
 	}
 
 	public void updateMemberPassword(Member member, String currentPassword, String newPassword,
 		String confirmPassword) {
+		String email = member.getEmail().getValue();
+
 		if (!member.isPasswordValid(currentPassword, passwordEncoder)) {
-			log.warn("비밀번호 변경 실패 - 기존 비밀번호 불일치 - userEmail: {}", member.getEmail().getValue());
+			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 기존 비밀번호 불일치", "email: " + email);
 			throw new BusinessException(StatusCode.UNAUTHORIZED, "기존 비밀번호가 일치하지 않습니다.");
 		}
 
 		if(newPassword.equals(currentPassword)) {
-			log.warn("비밀번호 변경 실패 - 새로운 비밀번호가 기존 비밀번호와 동일함 - userEmail: {}", member.getEmail().getValue());
+			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 새로운 비밀번호가 기존 비밀번호와 동일함", "email: " + email);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "기존 비밀번호와 새로운 비밀번호가 동일합니다.");
 		}
 
 		if (!newPassword.equals(confirmPassword)) {
-			log.warn("비밀번호 변경 실패 - 새 비밀번호가 일치하지 않음 - userEmail: {}", member.getEmail().getValue());
+			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 새 비밀번호가 일치하지 않음", "email: " + email);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "새로운 비밀번호가 서로 일치하지 않습니다.");
 		}
 
 		member.changePassword(passwordEncoder.encode(newPassword));
-
 		memberRepository.save(member);
-	}
-
-	public boolean isMemberPenalty(String email) {
-		Member member = getMemberByEmail(email);
-		return member.isPenalty();
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/util/MembershipLogUtil.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/util/MembershipLogUtil.java
@@ -1,0 +1,16 @@
+package com.ice.studyroom.domain.membership.domain.util;
+
+import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MembershipLogUtil {
+	public static void log(String message, Object... details) {
+		log.info("[MEMBERSHIP] {} - {}", message, Arrays.toString(details));
+	}
+
+	public static void logWarn(String message, Object... details) {
+		log.warn("[MEMBERSHIP] {} - {}", message, Arrays.toString(details));
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/application/PenaltyService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/application/PenaltyService.java
@@ -8,6 +8,7 @@ import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
 import com.ice.studyroom.domain.penalty.domain.service.PenaltyDomainService;
 import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
+import com.ice.studyroom.domain.penalty.domain.util.PenaltyLogUtil;
 import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
 import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
@@ -29,30 +30,38 @@ public class PenaltyService {
 
 	@Transactional
 	public void assignPenalty(Member member, Long reservationId, PenaltyReasonType reason) {
-		log.info("패널티 부여 요청 - userId: {}, reservationId: {}, reason: {}", member.getId(), reservationId, reason);
+		PenaltyLogUtil.log("패널티 부여 요청", "학번: " + member.getStudentNum(), "reservationId: " + reservationId, "reason: " + reason);
 		Reservation reservation = reservationRepository.findById(reservationId).
 			orElseThrow(() -> {
-				log.warn("패널티 조회 실패 - 유효한 패널티 없음 - userId: {}", member.getId());
+				PenaltyLogUtil.logWarn("패널티 부여 실패 - 존재하지 않는 예약", "reservationId: " + reservationId);
 				return new BusinessException(StatusCode.NOT_FOUND, "예약 정보를 찾을 수 없습니다.");
 			});
 
 		Penalty penalty = penaltyDomainService.createPenalty(member, reservation, reason, null);
 		member.updatePenalty(true);
 		penaltyRepository.save(penalty);
-		log.info("패널티 저장 완료 - penaltyId: {}", penalty.getId());
+		PenaltyLogUtil.log("패널티 부여 완료",
+			"패널티 ID: " + penalty.getId(),
+			"학번: " + member.getStudentNum(),
+			"사유: " + reason.name());
 	}
 
 	public void adminAssignPenalty(Member member, LocalDateTime penaltyEndAt) {
-		log.info("관리자 패널티 수동 부여 - userId: {}, 종료일시: {}", member.getId(), penaltyEndAt);
+		PenaltyLogUtil.log("관리자 패널티 수동 부여 요청", "학번: " + member.getStudentNum(), "종료일자: " + penaltyEndAt);
 		Penalty penalty = penaltyDomainService.createPenalty(member, null, PenaltyReasonType.ADMIN, penaltyEndAt);
 		member.updatePenalty(true);
 		penaltyRepository.save(penalty);
+		PenaltyLogUtil.log("패널티 부여 완료",
+			"패널티 ID: " + penalty.getId(),
+			"학번: " + member.getStudentNum(),
+			"사유: " + PenaltyReasonType.ADMIN);
 	}
 
 	public void adminDeletePenalty(Member member) {
-		log.info("관리자 패널티 삭제 요청 - userId: {}", member.getId());
+		PenaltyLogUtil.log("관리자 패널티 삭제 요청", "학번: " + member.getStudentNum());
 		Penalty penalty = penaltyDomainService.findPenaltyByMemberIdAndStatus(member);
 		penalty.expirePenalty();
 		member.updatePenalty(false);
+		PenaltyLogUtil.log("관리자 패널티 삭제 완료", "학번: " + member.getStudentNum(), "패널티 ID: " + penalty.getId());
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/service/PenaltyDomainService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/service/PenaltyDomainService.java
@@ -12,6 +12,7 @@ import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.penalty.domain.entity.Penalty;
 import com.ice.studyroom.domain.penalty.domain.type.PenaltyReasonType;
 import com.ice.studyroom.domain.penalty.domain.type.PenaltyStatus;
+import com.ice.studyroom.domain.penalty.domain.util.PenaltyLogUtil;
 import com.ice.studyroom.domain.penalty.infrastructure.persistence.PenaltyRepository;
 import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import com.ice.studyroom.global.exception.BusinessException;
@@ -33,12 +34,6 @@ public class PenaltyDomainService {
 		LocalDateTime penaltyEndAt) {
 		LocalDateTime end = (reason == PenaltyReasonType.ADMIN)? penaltyEndAt : calculatePenaltyEnd(reason.getDurationDays());
 
-		log.info("패널티 생성 - userId: {}, reservationId: {}, reason: {}, 종료일시: {}",
-			member.getId(),
-			reservation.getId(),
-			reason,
-			end);
-
 		return Penalty.builder()
 			.member(member)
 			.reservation(reservation)
@@ -50,7 +45,7 @@ public class PenaltyDomainService {
 	public Penalty findPenaltyByMemberIdAndStatus(Member member){
 		return penaltyRepository.findByMemberIdAndStatus(member.getId(), PenaltyStatus.VALID).orElseThrow(
 			() -> {
-				log.warn("패널티 조회 실패 - 유효한 패널티 없음 - userId: {}", member.getId());
+				PenaltyLogUtil.logWarn("패널티 조회 실패 - 유효한 패널티 없음", "학번: " + member.getStudentNum());
 				return new BusinessException(StatusCode.NOT_FOUND, "유효하지 않은 패널티입니다.");
 			}
 		);

--- a/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/util/PenaltyLogUtil.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/penalty/domain/util/PenaltyLogUtil.java
@@ -1,0 +1,16 @@
+package com.ice.studyroom.domain.penalty.domain.util;
+
+import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PenaltyLogUtil {
+	public static void log(String message, Object... details) {
+		log.info("[PENALTY] {} - {}", message, Arrays.toString(details));
+	}
+
+	public static void logWarn(String message, Object... details) {
+		log.warn("[PENALTY] {} - {}", message, Arrays.toString(details));
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -84,7 +84,7 @@ public class ReservationService {
 
 		Member reservationOwner = memberRepository.findByEmail(Email.of(reservationOwnerEmail))
 			.orElseThrow(() -> {
-				log.warn("내 예약 정보 조회 요청 - 존재하지 않는 회원 이메일: {}", reservationOwnerEmail);
+				ReservationLogUtil.logWarn("내 예약 정보 조회 실패 - 존재하지 않는 회원", "email: " + reservationOwnerEmail);
 				return new BusinessException(StatusCode.UNAUTHORIZED, "회원 정보를 찾을 수 없습니다.");
 			});
 
@@ -128,23 +128,23 @@ public class ReservationService {
 	public String getMyReservationQrCode(Long reservationId, String authorizationHeader) {
 		String reservationOwnerEmail = tokenService.extractEmailFromAccessToken(authorizationHeader);
 
-		log.info("QR코드 요청 수신 - userEmail: {}, reservationId: {}", reservationOwnerEmail, reservationId);
+		ReservationLogUtil.log("QR코드 요청 수신", "예약 ID: " + reservationId);
 
 		// 예약이 유효한지 확인
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> {
-				log.warn("QR코드 요청 실패 - 존재하지 않는 예약 - reservationId: {}", reservationId);
+				ReservationLogUtil.logWarn("QR코드 요청 실패 - 존재하지 않는 예약","예약 ID: " + reservationId);
 				return new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 예약입니다.");
 			});
 
 		if(reservation.getStatus() != ReservationStatus.RESERVED){
-			log.warn("QR코드 요청 실패 - 예약 상태 불일치 - reservationId: {}, status: {}", reservationId, reservation.getStatus());
+			ReservationLogUtil.logWarn("QR코드 요청 실패 - 예약 상태 아님", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "예약 상태가 아닙니다.");
 		}
 
 		// 해당 사용자의 예약인지 확인
 		if (!reservation.isOwnedBy(reservationOwnerEmail)) {
-			log.warn("QR코드 요청 실패 - 예약 접근 권한 없음 - userEmail: {}, reservationId: {}", reservationOwnerEmail, reservationId);
+			ReservationLogUtil.logWarn("QR코드 요청 실패 - 예약 접근 권한 없음", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.FORBIDDEN, "해당 예약에 접근할 수 없습니다.");
 		}
 
@@ -154,16 +154,14 @@ public class ReservationService {
 			token = SecureTokenUtil.generate(10);
 			reservation.assignQrToken(token);
 			reservationRepository.save(reservation);
-			log.info("QR 토큰 생성 및 저장 - reservationId: {}, token: {}", reservationId, token);
+			ReservationLogUtil.log("QR코드 생성 완료", "예약 ID: " + reservationId);
 		} else {
-			log.info("QR 토큰 재사용 - reservationId: {}, token: {}", reservationId, token);
+			ReservationLogUtil.log("QR코드 재사용", "예약 ID: " + reservationId);
 		}
 
 		qrCodeService.storeToken(token, reservation.getId());
-		log.info("QR 토큰 저장 완료 - reservationId: {}", reservationId);
-
 		String qrCode = qrCodeUtil.generateQRCodeFromToken(token);
-		log.info("QR 코드 생성 완료 - reservationId: {}", reservationId);
+		ReservationLogUtil.log("QR 토큰 저장 및 생성 완료", "예약 ID: " + reservationId);
 		return qrCode;
 	}
 
@@ -171,59 +169,56 @@ public class ReservationService {
 	public QrEntranceResponse qrEntrance(QrEntranceRequest request) {
 		// 클라이언트로부터 전달된 토큰 저장
 		String token = request.qrToken();
-		log.info("QR 입장 요청 수신 - token: {}", token);
 
 		// 토큰으로 예약 ID 조회
 		Long reservationId = qrCodeService.getReservationIdByToken(token);
 		if (reservationId == null) {
-			log.warn("유효하지 않은 QR 토큰 - token: {}", token);
+			ReservationLogUtil.logWarn("QR 입장 실패 - 유효하지 않은 QR 토큰", token);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "만료되었거나 유효하지 않은 QR 코드입니다.");
 		}
+
+		ReservationLogUtil.log("QR 입장 요청 수신", "예약 ID: " + reservationId);
 
 		// RDB에 존재하지않는 예약의 경우
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> {
-				log.warn("QR 입장 실패 - 존재하지 않는 예약 - reservationId: {}", reservationId);
+				ReservationLogUtil.logWarn("QR 입장 실패 - 존재하지 않는 예약", "예약 ID: " + reservationId);
 				return new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 예약입니다.");
 			});
-
-		log.info("예약 조회 성공 - reservationId: {}", reservationId);
 
 		Member reservationOwner = reservation.getMember();
 
 		// 예약의 상태에 따른 에러 처리
 		if(reservation.getStatus() == ReservationStatus.CANCELLED){
-			log.warn("입장 실패 - 취소된 예약 - reservationId: {}", reservationId);
+			ReservationLogUtil.logWarn("QR 입장 실패 - 취소된 예약", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "취소된 예약입니다.");
 		} else if(reservation.getStatus() == ReservationStatus.ENTRANCE || reservation.getStatus() == ReservationStatus.LATE){
-			log.warn("입장 실패 - 이미 입장 처리된 예약 - reservationId: {}", reservationId);
+			ReservationLogUtil.logWarn("QR 입장 실패 - 이미 입장 처리된 예약", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "이미 입실처리 된 예약입니다.");
 		}
 
 		LocalDateTime now = LocalDateTime.now(clock);
 		ReservationStatus status = reservation.checkAttendanceStatus(now);
 
-		log.info("입장 상태 판단 - reservationId: {}, 상태: {}, 시간: {}", reservationId, status, now);
-
 		reservation.updateEnterTime(now);
 		reservation.markStatus(status);
 
 		// qr 무효화
 		qrCodeService.invalidateToken(token);
-		log.info("QR 토큰 무효화 완료 - token: {}", token);
 
 		if (status == ReservationStatus.RESERVED) {
-			log.warn("입장 실패 - 출석 시간 아님 - reservationId: {}", reservationId);
+			ReservationLogUtil.logWarn("QR 입장 실패 - 출석 시간 아님", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "출석 시간이 아닙니다.");
 		} else if (status == ReservationStatus.NO_SHOW) {
-			log.warn("입장 실패 - 출석 시간 만료 - reservationId: {}", reservationId);
+			ReservationLogUtil.logWarn("QR 입장 실패 - 출석 시간 만료", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "출석 시간이 만료되었습니다.");
 		} else if(status == ReservationStatus.LATE){
-			log.warn("지각 입장 - 패널티 부여 - reservationId: {}, userId: {}", reservationId, reservationOwner.getId());
+			ReservationLogUtil.logWarn("지각 입장 - 패널티 부여", "예약 ID: " + reservationId,
+				"userId: " + reservationOwner.getEmail().getValue());
 			penaltyService.assignPenalty(reservationOwner, reservationId, PenaltyReasonType.LATE);
 		}
 
-		log.info("입장 처리 완료 - reservationId: {}, 최종 상태: {}", reservationId, status);
+		ReservationLogUtil.log("QR 입장 처리 완료", "예약 ID: " + reservationId);
 		return new QrEntranceResponse(status, reservationOwner.getName(), reservationOwner.getStudentNum());
 	}
 
@@ -231,12 +226,12 @@ public class ReservationService {
 	public String createIndividualReservation(String authorizationHeader, CreateReservationRequest request) {
 		// Access Token 에서 예약자 이메일 추출
 		String reservationOwnerEmail = tokenService.extractEmailFromAccessToken(authorizationHeader);
-		ReservationLogUtil.logReservationRequest(RoomType.INDIVIDUAL, request.scheduleId(), request.participantEmail());
+		ReservationLogUtil.log("개인 예약 생성 요청", "스케줄 ID: " + Arrays.toString(request.scheduleId()), "참여자 이메일: " + Arrays.toString(request.participantEmail()));
 
 		// 예약자 확인
 		Member reservationOwner = memberRepository.findByEmail(Email.of(reservationOwnerEmail))
 			.orElseThrow(() -> {
-				ReservationLogUtil.logReservationFailure(RoomType.INDIVIDUAL, "존재하지 않는 예약자", reservationOwnerEmail);
+				ReservationLogUtil.logWarn("개인 예약 실패 - 존재하지 않는 예약자", "예약자 이메일: " + reservationOwnerEmail);
 				return new BusinessException(StatusCode.NOT_FOUND, "예약자 이메일이 존재하지 않습니다: " + reservationOwnerEmail);
 			});
 
@@ -245,7 +240,7 @@ public class ReservationService {
 		List<Schedule> schedules = scheduleRepository.findAllByIdIn(idList);
 
 		if (schedules.size() != idList.size()) {
-			ReservationLogUtil.logReservationFailure(RoomType.INDIVIDUAL, "존재하지 않는 스케줄 포함됨 ", idList);
+			ReservationLogUtil.logWarn("개인 예약 실패 - 존재하지 않는 스케줄 포함됨", "스케줄 ID: " + idList);
 			throw new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄이 포함되어 있습니다.");
 		}
 
@@ -253,13 +248,13 @@ public class ReservationService {
 
 		RoomType roomType = schedules.get(0).getRoomType();
 		if(roomType == RoomType.GROUP) {
-			ReservationLogUtil.logReservationFailure(RoomType.INDIVIDUAL, "그룹 전용 방 예약 시도", schedules.get(0).getRoomNumber());
+			ReservationLogUtil.logWarn("개인 예약 실패 - 그룹 전용 방 예약 시도","방 번호: " + schedules.get(0).getRoomNumber());
 			throw new BusinessException(StatusCode.FORBIDDEN, "해당 방은 단체예약 전용입니다.");
 		}
 
 		// 패널티 상태 확인 (예약 불가)
 		if (reservationOwner.isPenalty()) {
-			ReservationLogUtil.logReservationFailure(RoomType.INDIVIDUAL, "패널티 상태의 사용자", reservationOwnerEmail);
+			ReservationLogUtil.logWarn("개인 예약 실패 - 패널티 상태의 사용자", "예약자 이메일: " + reservationOwnerEmail);
 			throw new BusinessException(StatusCode.FORBIDDEN, "사용정지 상태입니다.");
 		}
 
@@ -272,7 +267,7 @@ public class ReservationService {
 		// 스케줄 업데이트 (currentRes 증가 및 상태 변경)
 		for (Schedule schedule : schedules) {
 			if (!schedule.isCurrentResLessThanCapacity()) {
-				ReservationLogUtil.logReservationFailure(RoomType.INDIVIDUAL, "수용 인원 초과", schedule.getId());
+					ReservationLogUtil.logWarn("개인 예약 실패 - 수용 인원 초과", "스케줄 ID: " + schedule.getId());
 				throw new BusinessException(StatusCode.BAD_REQUEST, "예약 가능한 자리가 없습니다.");
 			}
 
@@ -283,7 +278,7 @@ public class ReservationService {
 		}
 
 		scheduleRepository.saveAll(schedules);
-		ReservationLogUtil.logReservationSuccess(RoomType.INDIVIDUAL, reservation.getId());
+		ReservationLogUtil.log("개인 예약 생성 성공", "예약자: " + reservationOwnerEmail, "예약 ID: " + reservation.getId());
 		sendReservationSuccessEmail(roomType, reservationOwnerEmail, new HashSet<>(), schedules.get(0));
 
 		return "Success";
@@ -293,12 +288,12 @@ public class ReservationService {
 	public String createGroupReservation(String authorizationHeader, CreateReservationRequest request) {
 		// JWT에서 예약자 이메일 추출
 		String reservationOwnerEmail = tokenService.extractEmailFromAccessToken(authorizationHeader);
-		ReservationLogUtil.logReservationRequest(RoomType.GROUP, request.scheduleId(), request.participantEmail());
+		ReservationLogUtil.log("단체 예약 생성 요청", "스케줄 ID: " + Arrays.toString(request.scheduleId()), "참여자 이메일: " + Arrays.toString(request.participantEmail()));
 
 		// 예약자(User) 확인 및 user_name 가져오기
 		Member reservationOwner = memberRepository.findByEmail(Email.of(reservationOwnerEmail))
 			.orElseThrow(() -> {
-				ReservationLogUtil.logReservationFailure(RoomType.GROUP, "존재하지 않는 예약자", reservationOwnerEmail);
+				ReservationLogUtil.logWarn("단체 예약 실패 - 존재하지 않는 예약자", "예약자 이메일: " + reservationOwnerEmail);
 				return new BusinessException(StatusCode.NOT_FOUND, "예약자 이메일이 존재하지 않습니다: " + reservationOwnerEmail);
 			});
 
@@ -307,7 +302,7 @@ public class ReservationService {
 		List<Schedule> schedules = scheduleRepository.findAllByIdIn(idList);
 
 		if (schedules.size() != idList.size()) {
-			ReservationLogUtil.logReservationFailure(RoomType.GROUP, "존재하지 않는 스케줄 포함됨", idList);
+			ReservationLogUtil.logWarn("단체 예약 실패 - 존재하지 않는 스케줄 포함됨", "스케줄 ID: " + idList);
 			throw new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄이 포함되어 있습니다.");
 		}
 
@@ -316,12 +311,12 @@ public class ReservationService {
 		// 스케줄에서 Type을 저장해야하며, Type에 따른 RES 처리가 필요하다.
 		RoomType roomType = schedules.get(0).getRoomType();
 		if(roomType == RoomType.INDIVIDUAL) {
-			ReservationLogUtil.logReservationFailure(RoomType.GROUP, "개인 전용 방 예약 시도", schedules.get(0).getRoomNumber());
+			ReservationLogUtil.logWarn("단체 예약 실패 - 개인 전용 방 예약 시도", "방 번호: " + schedules.get(0).getRoomNumber());
 			throw new BusinessException(StatusCode.FORBIDDEN, "해당 방은 개인예약 전용입니다.");
 		}
 
 		if(reservationOwner.isPenalty()) {
-			ReservationLogUtil.logReservationFailure(RoomType.GROUP, "예약자가 패널티 상태", reservationOwnerEmail);
+			ReservationLogUtil.logWarn("단체 예약 실패 - 예약자가 패널티 상태", "예약자 이메일: " + reservationOwnerEmail);
 			throw new BusinessException(StatusCode.FORBIDDEN, "예약자가 패널티 상태입니다. 예약이 불가능합니다.");
 		}
 
@@ -340,18 +335,18 @@ public class ReservationService {
 		if (!ObjectUtils.isEmpty(request.participantEmail())) {
 			for (String email : request.participantEmail()) {
 				if (!uniqueEmails.add(email)) {
-					ReservationLogUtil.logReservationFailure(RoomType.GROUP, "중복된 참여자 이메일", email);
+						ReservationLogUtil.logWarn("단체 예약 실패 - 중복된 참여자 이메일", "이메일: " + email);
 					throw new BusinessException(StatusCode.BAD_REQUEST, "중복된 참여자 이메일이 존재합니다: " + email);
 				}
 				Member participant = memberRepository.findByEmail(Email.of(email))
 					.orElseThrow(() -> {
-						ReservationLogUtil.logReservationFailure(RoomType.GROUP, "존재하지 않는 참여자 이메일", email);
+						ReservationLogUtil.logWarn("단체 예약 실패 - 존재하지 않는 참여자 이메일", "이메일: " + email);
 						return new BusinessException(StatusCode.NOT_FOUND, "참여자 이메일이 존재하지 않습니다: " + email);
 					});
 
 				//참여자 패널티 상태 확인
 				if (participant.isPenalty()) {
-					ReservationLogUtil.logReservationFailure(RoomType.GROUP, "패널티 상태 참여자 존재", email);
+					ReservationLogUtil.logWarn("단체 예약 실패 - 패널티 상태 참여자 존재", "이메일: " + email);
 					throw new BusinessException(StatusCode.FORBIDDEN, "참여자 중 패널티 상태인 사용자가 있습니다. 예약이 불가능합니다. (이메일: " + email + ")");
 				}
 
@@ -360,7 +355,7 @@ public class ReservationService {
 				if(recentReservationOpt.isPresent()) {
 					ReservationStatus recentStatus = recentReservationOpt.get().getStatus();
 					if(recentStatus == ReservationStatus.RESERVED || recentStatus == ReservationStatus.ENTRANCE) {
-						ReservationLogUtil.logReservationFailure(RoomType.GROUP, "참여자가 이미 예약 중", email);
+						ReservationLogUtil.logWarn("단체 예약 실패 - 참여자가 이미 예약 중", "이메일: " + email);
 						throw new BusinessException(StatusCode.CONFLICT, "참여자 중 현재 예약이 진행 중인 사용자가 있어 예약이 불가능합니다. (이메일: " + email + ")");
 					}
 				}
@@ -374,11 +369,11 @@ public class ReservationService {
 		int minRes = schedules.get(0).getMinRes(); // 모든 Group 전용 schedule의 min_res는 2로 동일
 		int capacity = schedules.get(0).getCapacity(); // 같은 방의 schedule은 capacity는 동일
 		if (totalParticipants < minRes) {
-			ReservationLogUtil.logReservationFailure(RoomType.GROUP, "최소 인원 미달", "최소 인원: ", minRes);
+			ReservationLogUtil.logWarn("단체 예약 실패 - 최소 인원 미달", "최소 인원: " + minRes, "현재 인원: " + totalParticipants);
 			throw new BusinessException(StatusCode.BAD_REQUEST,
 				"최소 예약 인원 조건을 만족하지 않습니다. (필요 인원: " + minRes + ", 현재 인원: " + totalParticipants + ")");
 		}else if (totalParticipants > capacity) {
-			ReservationLogUtil.logReservationFailure(RoomType.GROUP, "최대 수용 인원 초과", "최대 인원: ", capacity);
+			ReservationLogUtil.logWarn("단체 예약 실패 - 최대 인원 초과", "최대 수용 인원: " + capacity, "현재 인원: " + totalParticipants);
 			throw new BusinessException(StatusCode.BAD_REQUEST,
 				"방의 최대 수용 인원을 초과했습니다. (최대 수용 인원: " + capacity + ", 현재 인원: " + totalParticipants + ")");
 		}
@@ -398,7 +393,7 @@ public class ReservationService {
 			schedule.updateGroupCurrentRes(totalParticipants); // 현재 사용 인원을 예약자 + 참여자 숫자로 지정
 			schedule.updateStatus(ScheduleSlotStatus.RESERVED);
 		}
-		ReservationLogUtil.logReservationSuccess(RoomType.GROUP, reservations.get(0).getId());
+		ReservationLogUtil.log("단체 예약 생성 성공", "예약자: " + reservationOwnerEmail, "참여자 수: " + (uniqueEmails.size()-1), "예약 ID: " + reservations.get(0).getId());
 
 		//전 인원에게 예약 확정 메일 발송
 		sendReservationSuccessEmail(roomType, reservationOwnerEmail, uniqueEmails, schedules.get(0));
@@ -409,11 +404,11 @@ public class ReservationService {
 	@Transactional
 	public CancelReservationResponse cancelReservation(Long reservationId, String authorizationHeader) {
 		String reservationOwnerEmail = tokenService.extractEmailFromAccessToken(authorizationHeader);
-		log.info("예약 취소 요청 수신 - userEmail: {}, reservationId: {}", reservationOwnerEmail, reservationId);
+		ReservationLogUtil.log("예약 취소 요청 수신", "예약 ID: " + reservationId);
 
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> {
-				log.warn("예약 취소 실패 - 존재하지 않는 예약 - reservationId: {}", reservationId);
+				ReservationLogUtil.logWarn("예약 취소 실패 - 존재하지 않는 예약", "예약 ID: " + reservationId);
 				return new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 예약입니다.");
 			});
 
@@ -421,7 +416,7 @@ public class ReservationService {
 
 		// JWT 를 통한 사용자 정보를 토대로, 본인의 예약인지 확인
 		if (!reservation.isOwnedBy(reservationOwnerEmail)) {
-			log.warn("예약 취소 실패 - 사용자 예약 아님 - userEmail: {}, reservationId: {}", reservationOwnerEmail, reservationId);
+			ReservationLogUtil.logWarn("예약 취소 실패 - 사용자 예약 아님","예약 ID: " + reservationId, "예약자 이메일: " + reservationOwnerEmail);
 			throw new BusinessException(StatusCode.NOT_FOUND, "이전에 예약이 되지 않았습니다.");
 		}
 
@@ -429,22 +424,21 @@ public class ReservationService {
 
 		Schedule firstSchedule = scheduleRepository.findById(reservation.getFirstScheduleId())
 			.orElseThrow(() -> {
-				log.warn("예약 취소 실패 - 예약에 연결된 스케줄 없음 - scheduleId: {}", reservation.getFirstScheduleId());
+				ReservationLogUtil.logWarn("예약 취소 실패 - 예약에 연결된 스케줄 없음", "예약 ID: " + reservationId);
 				return new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄입니다.");
 			});
 
 		LocalDateTime startTime = LocalDateTime.of(now.toLocalDate(), firstSchedule.getStartTime());
 
-		// 입실 1 시간 전 일 경우 패널티
 		if (now.isAfter(startTime)) {
-			log.warn("예약 취소 실패 - 입실 시간 초과 - reservationId: {}, now: {}, startTime: {}", reservationId, now, startTime);
+			ReservationLogUtil.logWarn("예약 취소 실패 - 입실 시간 초과", "예약 ID: " + reservationId, "입실 시간: " + startTime);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "입실 시간이 초과하였기에 취소할 수 없습니다.");
 		}
 
 		if (!now.isBefore(startTime.minusHours(1))) {
 			// 취소 패널티 부여
+			ReservationLogUtil.log("예약 취소 - 패널티 부여", "예약 ID: " + reservationId, "예약자 이메일: " + reservationOwnerEmail);
 			penaltyService.assignPenalty(reservationOwner, reservationId, PenaltyReasonType.CANCEL);
-			log.warn("예약 취소 패널티 부여 - userEmail: {}, reservationId: {}", reservationOwnerEmail, reservationId);
 		}
 
 		/*
@@ -454,35 +448,33 @@ public class ReservationService {
 		 */
 
 		firstSchedule.cancel();
-		log.info("예약 취소 - 첫 스케줄 상태 변경 완료 - scheduleId: {}", firstSchedule.getId());
 
 		Optional.ofNullable(reservation.getSecondScheduleId())
 			.flatMap(scheduleRepository::findById)
 			.ifPresent(schedule -> {
 				schedule.cancel();
-				log.info("예약 취소 - 두 번째 스케줄 상태 변경 완료 - scheduleId: {}", schedule.getId());
 			});
 
 		reservation.markStatus(ReservationStatus.CANCELLED);
-		log.info("예약 상태 CANCELLED 처리 완료 - reservationId: {}", reservationId);
+		ReservationLogUtil.log("예약 상태 CANCELLED 처리 완료", "예약 ID: " + reservationId);
 
 		return new CancelReservationResponse(reservationId);
 	}
 
 	@Transactional
 	public String extendReservation(Long reservationId, String authorizationHeader) {
-		log.info("예약 연장 요청 수신 - reservationId: {}", reservationId);
+		ReservationLogUtil.log("예약 연장 요청 수신", "예약 ID: " + reservationId);
 
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> {
-				log.warn("예약 연장 실패 - 존재하지 않는 예약 - reservationId: {}", reservationId);
+				ReservationLogUtil.logWarn("예약 연장 실패 - 존재하지 않는 예약", "예약 ID: " + reservationId);
 				return new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 예약입니다.");
 			});
 
 		String reservationOwnerEmail = tokenService.extractEmailFromAccessToken(authorizationHeader);
 
 		if (!reservation.isOwnedBy(reservationOwnerEmail)) {
-			log.warn("예약 연장 실패 - 예약자 불일치 - userEmail: {}, reservationId: {}", reservationOwnerEmail, reservationId);
+			ReservationLogUtil.logWarn("예약 연장 실패 - 예약자 불일치", "예약 ID: " + reservationId, "예약자 이메일: " + reservationOwnerEmail);
 			throw new BusinessException(StatusCode.NOT_FOUND, "해당 예약 정보가 존재하지 않습니다.");
 		}
 
@@ -490,10 +482,10 @@ public class ReservationService {
 		LocalDateTime now = LocalDateTime.now(clock);
 		LocalDateTime endTime = LocalDateTime.of(reservation.getScheduleDate(), reservation.getEndTime());
 		if (now.isAfter(endTime)) {
-			log.warn("예약 연장 실패 - 퇴실 시간 이후 요청 - reservationId: {}, now: {}, endTime: {}", reservationId, now, endTime);
+			ReservationLogUtil.logWarn("예약 연장 실패 - 퇴실 시간 이후 요청", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "연장 가능한 시간이 지났습니다.");
 		} else if (now.isBefore(endTime.minusMinutes(10))) {
-			log.warn("예약 연장 실패 - 연장 가능 시간 아님 - reservationId: {}, now: {}, 연장 가능 시점: {}", reservationId, now, endTime.minusMinutes(10));
+			ReservationLogUtil.logWarn("예약 연장 실패 - 연장 가능 시간 아님", "예약 ID: " + reservationId);
 			throw new BusinessException(StatusCode.BAD_REQUEST, "연장은 퇴실 시간 10분 전부터 가능합니다.");
 		}
 
@@ -503,22 +495,22 @@ public class ReservationService {
 		//예약의 마지막 스케줄 ID를 통해 다음 스케줄을 찾는다.
 		Schedule nextSchedule = scheduleRepository.findById(lastScheduleId + 1)
 			.orElseThrow(() -> {
-				log.warn("예약 연장 실패 - 다음 스케줄 없음 - 요청 스케줄ID: {}", lastScheduleId + 1);
+				ReservationLogUtil.logWarn("예약 연장 실패 - 다음 스케줄 없음", "예약 ID: " + reservationId);
 				return new BusinessException(StatusCode.NOT_FOUND, "스터디룸 이용 가능 시간을 확인해주세요.");
 			});
 
 		if (!nextSchedule.getRoomNumber().equals(reservation.getRoomNumber())){
-			log.warn("예약 연장 실패 - 다른 방 스케줄 연결 시도 - 예약방: {}, 다음스케줄 방: {}", reservation.getRoomNumber(), nextSchedule.getRoomNumber());
+			ReservationLogUtil.logWarn("예약 연장 실패 - 다른 방 스케줄 연결 시도", "예약방: " + reservation.getRoomNumber(), "다음스케줄 방: " + nextSchedule.getRoomNumber());
 			throw new BusinessException(StatusCode.BAD_REQUEST, "스터디룸 이용 가능 시간을 확인해주세요.");
 		}
 
 		if (!nextSchedule.isCurrentResLessThanCapacity() || !nextSchedule.isAvailable()) {
-			log.warn("예약 연장 실패 - 다음 시간대 이용 불가 또는 인원 초과 - scheduleId: {}", nextSchedule.getId());
+			ReservationLogUtil.logWarn("예약 연장 실패 - 다음 시간대 이용 불가 또는 인원 초과", "다음 스케줄 ID: " + nextSchedule.getId());
 			throw new BusinessException(StatusCode.BAD_REQUEST, "다음 시간대가 이미 예약이 완료되었거나, 이용이 불가능한 상태입니다.");
 		}
 
 		if (nextSchedule.getRoomType() == RoomType.GROUP) {
-			log.info("그룹 예약 연장 검증 시작 - reservationId: {}", reservationId);
+			ReservationLogUtil.log("그룹 예약 연장 검증 시작", "예약 ID: " + reservationId);
 			// 그룹 예약 이기에 같은 시간대의 예약 레코드를 모두 가져온다(참여자 검증 필요).
 			List<Reservation> reservations = reservationRepository.findByFirstScheduleId(reservation.getFirstScheduleId());
 
@@ -528,14 +520,16 @@ public class ReservationService {
 				if (res.getStatus() == ReservationStatus.CANCELLED) continue;
 
 				if (res.getMember().isPenalty()) {
-					log.warn("그룹 예약 연장 실패 - 패널티 상태 참여자 존재 - userEmail: {}", res.getMember().getEmail().getValue());
+					ReservationLogUtil.logWarn("그룹 예약 연장 실패 - 패널티 상태 참여자 존재",
+						"이메일: " + res.getMember().getEmail().getValue());
 					throw new BusinessException(StatusCode.FORBIDDEN, "패널티가 있는 멤버로 인해 연장이 불가능합니다.");
 				}
 
 				//1명이라도 입실하지 않은 경우
 				if (!res.isEntered()){
 					//지각 입실은 앞서 패널티 체킹으로 연장 불가 처리
-					log.warn("그룹 예약 연장 실패 - 입실하지 않은 참여자 존재 - userEmail: {}", res.getMember().getEmail().getValue());
+					ReservationLogUtil.logWarn("그룹 예약 연장 실패 - 입실하지 않은 참여자 존재",
+						"이메일: " + res.getMember().getEmail().getValue());
 					throw new BusinessException(StatusCode.BAD_REQUEST, "입실 처리 되어있지 않은 유저가 있어 연장이 불가능합니다.");
 				}
 			}
@@ -544,30 +538,31 @@ public class ReservationService {
 				if (res.getStatus() == ReservationStatus.CANCELLED) continue;
 				res.extendReservation(nextSchedule.getId(), nextSchedule.getEndTime());
 				nextSchedule.reserve();
-				log.info("그룹 예약 연장 완료 - userEmail: {}, reservationId: {}", res.getMember().getEmail().getValue(), res.getId());
+				ReservationLogUtil.log("그룹 예약 연장 완료", "참여자 이메일: " + res.getMember().getEmail().getValue(), "예약 ID: " + res.getId());
+
 			}
 			nextSchedule.updateStatus(ScheduleSlotStatus.RESERVED);
 
 		} else {
 			if(reservation.getMember().isPenalty()){
-				log.warn("개인 예약 연장 실패 - 패널티 상태 사용자 - userEmail: {}", reservationOwnerEmail);
+				ReservationLogUtil.logWarn("개인 예약 연장 실패 - 패널티 상태 사용자", "예약자 이메일: " + reservationOwnerEmail);
 				throw new BusinessException(StatusCode.BAD_REQUEST, "패넡티 상태이므로, 연장이 불가능합니다.");
 			}
 
 			if(!reservation.isEntered()){
-				log.warn("개인 예약 연장 실패 - 입실하지 않은 사용자 - reservationId: {}", reservationId);
+				ReservationLogUtil.logWarn("개인 예약 연장 실패 - 입실하지 않은 사용자", "예약자 이메일: " + reservationOwnerEmail);
 				throw new BusinessException(StatusCode.BAD_REQUEST, "예약 연장은 입실 후 가능합니다.");
 			}
 			reservation.extendReservation(nextSchedule.getId(), nextSchedule.getEndTime());
 			nextSchedule.reserve();
-			log.info("개인 예약 연장 완료 - reservationId: {}, scheduleId: {}", reservationId, nextSchedule.getId());
+			ReservationLogUtil.log("개인 예약 연장 완료", "예약자 이메일: " + reservationOwnerEmail, "예약 ID: " + reservation.getId());
 
 			if (!nextSchedule.isCurrentResLessThanCapacity()){
 				nextSchedule.updateStatus(ScheduleSlotStatus.RESERVED);
 			}
 		}
 
-		log.info("예약 연장 최종 완료 - reservationId: {}, nextScheduleId: {}", reservationId, nextSchedule.getId());
+		ReservationLogUtil.log("예약 연장 최종 완료", "예약자 이메일: " + reservationOwnerEmail);
 		return "Success";
 	}
 
@@ -597,18 +592,21 @@ public class ReservationService {
 				!schedule.isCurrentResLessThanCapacity() ||
 				!scheduleStartDateTime.isAfter(now); // 현재 시간보다 이전이면 예외 발생
 		})) {
-			log.warn("스케줄 유효성 검증 실패 - 현재 시간: {}, scheduleIds: {}", now,
-				schedules.stream().map(Schedule::getId).toList());
+			ReservationLogUtil.logWarn("스케줄 유효성 검증 실패",
+				"현재 시간: " + now,
+				"대상 스케줄 ID 목록: " + schedules.stream().map(Schedule::getId).toList());
 			throw new BusinessException(StatusCode.BAD_REQUEST, "예약이 불가능합니다. 스케줄이 유효하지 않거나 이미 예약이 완료되었습니다.");
 		}
 	}
 
-	private void checkDuplicateReservation(Email reservationOwnerEmail){
-		Optional<Reservation> recentReservation = reservationRepository.findLatestReservationByMemberEmail(reservationOwnerEmail);
+	private void checkDuplicateReservation(Email reservationOwnerEmail) {
+		Optional<Reservation> recentReservation = reservationRepository.findLatestReservationByMemberEmail(
+			reservationOwnerEmail);
 		if (recentReservation.isPresent()) {
 			ReservationStatus recentStatus = recentReservation.get().getStatus();
 			if (recentStatus == ReservationStatus.RESERVED || recentStatus == ReservationStatus.ENTRANCE) {
-				log.warn("중복 예약 시도 - userEmail: {}, 현재 상태: {}", reservationOwnerEmail.getValue(), recentStatus);
+				ReservationLogUtil.logWarn("중복 예약 시도",
+					"userEmail: " + reservationOwnerEmail.getValue() + "현재 상태: " + recentStatus);
 				throw new BusinessException(StatusCode.CONFLICT, "현재 예약이 진행 중이므로 새로운 예약을 생성할 수 없습니다.");
 			}
 		}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -137,10 +137,10 @@ public class ReservationService {
 				return new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 예약입니다.");
 			});
 
-		if(reservation.getStatus() != ReservationStatus.RESERVED){
-			ReservationLogUtil.logWarn("QR코드 요청 실패 - 예약 상태 아님", "예약 ID: " + reservationId);
-			throw new BusinessException(StatusCode.BAD_REQUEST, "예약 상태가 아닙니다.");
-		}
+		// if(reservation.getStatus() != ReservationStatus.RESERVED){
+		// 	ReservationLogUtil.logWarn("QR코드 요청 실패 - 예약 상태 아님", "예약 ID: " + reservationId);
+		// 	throw new BusinessException(StatusCode.BAD_REQUEST, "예약 상태가 아닙니다.");
+		// }
 
 		// 해당 사용자의 예약인지 확인
 		if (!reservation.isOwnedBy(reservationOwnerEmail)) {
@@ -521,7 +521,7 @@ public class ReservationService {
 
 				if (res.getMember().isPenalty()) {
 					ReservationLogUtil.logWarn("그룹 예약 연장 실패 - 패널티 상태 참여자 존재",
-						"이메일: " + res.getMember().getEmail().getValue());
+						"이메일: " + res.getMember().getEmail());
 					throw new BusinessException(StatusCode.FORBIDDEN, "패널티가 있는 멤버로 인해 연장이 불가능합니다.");
 				}
 
@@ -529,7 +529,7 @@ public class ReservationService {
 				if (!res.isEntered()){
 					//지각 입실은 앞서 패널티 체킹으로 연장 불가 처리
 					ReservationLogUtil.logWarn("그룹 예약 연장 실패 - 입실하지 않은 참여자 존재",
-						"이메일: " + res.getMember().getEmail().getValue());
+						"이메일: " + res.getMember().getEmail());
 					throw new BusinessException(StatusCode.BAD_REQUEST, "입실 처리 되어있지 않은 유저가 있어 연장이 불가능합니다.");
 				}
 			}
@@ -538,8 +538,7 @@ public class ReservationService {
 				if (res.getStatus() == ReservationStatus.CANCELLED) continue;
 				res.extendReservation(nextSchedule.getId(), nextSchedule.getEndTime());
 				nextSchedule.reserve();
-				ReservationLogUtil.log("그룹 예약 연장 완료", "참여자 이메일: " + res.getMember().getEmail().getValue(), "예약 ID: " + res.getId());
-
+				ReservationLogUtil.log("그룹 예약 연장 완료", "참여자 이메일: " + res.getMember().getEmail(), "예약 ID: " + res.getId());
 			}
 			nextSchedule.updateStatus(ScheduleSlotStatus.RESERVED);
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/util/ReservationLogUtil.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/util/ReservationLogUtil.java
@@ -1,32 +1,18 @@
 package com.ice.studyroom.domain.reservation.util;
 
 import java.util.Arrays;
-import java.util.List;
-
-import com.ice.studyroom.domain.admin.domain.type.RoomType;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ReservationLogUtil {
 
-	public static void logReservationRequest(RoomType type, Long[] scheduleIds, String[] participantEmails) {
-		log.info("[RESERVATION] {} 예약 생성 요청 - scheduleIds: {} / participantEmails: {} ", getRoomTypeString(type),
-			scheduleIds, participantEmails);
+	public static void log(String message, Object... details) {
+		log.info("[RESERVATION] {} - {}", message, Arrays.toString(details));
 	}
 
-	public static void logReservationSuccess(RoomType type, Long reservationId) {
-		log.info("[RESERVATION] {} 예약 생성 성공 - reservationId: {}", getRoomTypeString(type), reservationId);
+	public static void logWarn(String message, Object... details) {
+		log.warn("[RESERVATION] {} - {}", message, Arrays.toString(details));
 	}
 
-	public static void logReservationFailure(RoomType type, String reason, Object... args) {
-		log.warn("[RESERVATION] {} 예약 실패 - 이유 : {} / {}", getRoomTypeString(type), reason, Arrays.toString(args));
-	}
-
-	private static String getRoomTypeString(RoomType type) {
-		return switch (type) {
-			case GROUP -> "그룹";
-			case INDIVIDUAL -> "개인";
-		};
-	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/util/ReservationLogUtil.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/util/ReservationLogUtil.java
@@ -1,0 +1,32 @@
+package com.ice.studyroom.domain.reservation.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReservationLogUtil {
+
+	public static void logReservationRequest(RoomType type, Long[] scheduleIds, String[] participantEmails) {
+		log.info("[RESERVATION] {} 예약 생성 요청 - scheduleIds: {} / participantEmails: {} ", getRoomTypeString(type),
+			scheduleIds, participantEmails);
+	}
+
+	public static void logReservationSuccess(RoomType type, Long reservationId) {
+		log.info("[RESERVATION] {} 예약 생성 성공 - reservationId: {}", getRoomTypeString(type), reservationId);
+	}
+
+	public static void logReservationFailure(RoomType type, String reason, Object... args) {
+		log.warn("[RESERVATION] {} 예약 실패 - 이유 : {} / {}", getRoomTypeString(type), reason, Arrays.toString(args));
+	}
+
+	private static String getRoomTypeString(RoomType type) {
+		return switch (type) {
+			case GROUP -> "그룹";
+			case INDIVIDUAL -> "개인";
+		};
+	}
+}

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/GroupReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/GroupReservationTest.java
@@ -136,6 +136,7 @@ public class GroupReservationTest {
 		시간_고정_셋업(12, 30);
 		스케줄_리스트_설정(request.scheduleId(),schedule);
 		스케줄_설정(schedule, ScheduleSlotStatus.RESERVED, RoomType.GROUP, 13, 0);
+		예약자_존재확인();
 
 		// when & then
 		BusinessException ex = assertThrows(BusinessException.class, () ->
@@ -179,6 +180,7 @@ public class GroupReservationTest {
 		시간_고정_셋업(13, 1);
 		스케줄_리스트_설정(request.scheduleId(),schedule);
 		스케줄_설정(schedule, ScheduleSlotStatus.AVAILABLE, RoomType.GROUP, 13, 0);
+		예약자_존재확인();
 
 		// when & then
 		BusinessException ex = assertThrows(BusinessException.class, () ->
@@ -221,6 +223,7 @@ public class GroupReservationTest {
 
 		시간_고정_셋업(12, 30);
 		스케줄_리스트_설정(request.scheduleId(),schedule);
+		예약자_존재확인();
 
 		//스케줄을 개인방으로 설정
 		스케줄_설정(schedule, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 0);
@@ -709,7 +712,8 @@ public class GroupReservationTest {
 		given(clock.getZone()).willReturn(ZoneId.systemDefault());
 	}
 
-	void 스케줄_리스트_설정(Long[] ids, Schedule... schedules) {
+	void
+	스케줄_리스트_설정(Long[] ids, Schedule... schedules) {
 		given(scheduleRepository.findAllByIdIn(Arrays.stream(ids).toList()))
 			.willReturn(List.of(schedules));
 	}

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/IndividualReservationTest.java
@@ -219,6 +219,7 @@ class IndividualReservationTest {
 		시간_고정_셋업(13, 0);
 		스케줄_리스트_설정(request.scheduleId(), firstSchedule);
 		스케줄_설정(firstSchedule, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 0);
+		예약자_패널티_설정(false);
 
 		// when & then
 		BusinessException ex = assertThrows(BusinessException.class, () ->
@@ -261,6 +262,7 @@ class IndividualReservationTest {
 		시간_고정_셋업(12, 30);
 		스케줄_리스트_설정(request.scheduleId(), firstSchedule);
 		스케줄_설정(firstSchedule, ScheduleSlotStatus.RESERVED, RoomType.INDIVIDUAL, 13, 0);
+		예약자_패널티_설정(false);
 
 		// when & then
 		BusinessException ex = assertThrows(BusinessException.class, () ->
@@ -304,6 +306,7 @@ class IndividualReservationTest {
 		시간_고정_셋업(12, 30);
 		스케줄_리스트_설정(request.scheduleId(), firstSchedule);
 		스케줄_설정(firstSchedule, ScheduleSlotStatus.AVAILABLE, RoomType.GROUP, 13, 30);
+		예약자_패널티_설정(false);
 
 		// when & then
 		BusinessException ex = assertThrows(BusinessException.class, () ->
@@ -343,9 +346,9 @@ class IndividualReservationTest {
 			new String[]{}
 		);
 
-		시간_고정_셋업(12, 30);
-		스케줄_리스트_설정(request.scheduleId(), firstSchedule);
-		스케줄_설정(firstSchedule, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
+		// 시간_고정_셋업(12, 30);
+		// 스케줄_리스트_설정(request.scheduleId(), firstSchedule);
+		// 스케줄_설정(firstSchedule, ScheduleSlotStatus.AVAILABLE, RoomType.INDIVIDUAL, 13, 30);
 
 		given(tokenService.extractEmailFromAccessToken(token)).willReturn(email);
 		given(memberRepository.findByEmail(Email.of(email))).willReturn(Optional.empty());


### PR DESCRIPTION
## PR 종류
- [x] 기능 개선

## 변경 사항

- 도메인 전반의 로깅 메시지를 통일된 포맷으로 개선하고, 로깅 유틸리티 클래스를 적용
- 불필요한 중복 로그 제거 및 로그의 의미 명확화를 통해 유지보수성과 지표 수집 효율성을 향상
- 예약/패널티/회원/관리자 서비스 내 주요 로직 수행 시점에 통일된 로그 메시지를 출력하도록 변경

## 관련 이슈

#478 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- ReservationLogUtil, PenaltyLogUtil, MemberLogUtil, AdminLogUtil 도입
- 금일 패널티 부여 수, 패널티 사유별 비율 등 로그 기반 지표 수집을 위한 메시지 포맷 개선
- 각 서비스에 로깅 유틸 적용 완료 (ReservationService, PenaltyService, MembershipService, AdminService 등)

## 기타

- LogQL 기반 지표 대시보드 구축을 위한 로그 구조 기반을 위한 작업입니다.
- 로그를 작성하면서, 비즈니스 로직에서 조회하는 순서가 바뀌었습니다. 그로인해 테스트 코드에 변경이 있습니다.
