### PR TITLE
[BE-#484] Membership 도메인의 이메일, 비밀번호 비즈니스 로직 분리 및 VO를 활용한 자기 유효성 검사 구현

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/IceStudyRoomApplication.java
+++ b/backend/src/main/java/com/ice/studyroom/IceStudyRoomApplication.java
@@ -2,7 +2,9 @@ package com.ice.studyroom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class IceStudyRoomApplication {
 

--- a/backend/src/main/java/com/ice/studyroom/domain/identity/domain/SecurityUser.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/identity/domain/SecurityUser.java
@@ -25,7 +25,7 @@ public class SecurityUser implements UserDetails {
 
 	@Override
 	public String getPassword() {
-		return user.getPassword();
+		return user.getPassword().getValue();
 	}
 
 	@Override

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
@@ -3,6 +3,9 @@ package com.ice.studyroom.domain.membership.domain.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ice.studyroom.domain.membership.domain.service.encrypt.PasswordEncryptor;
+import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
+import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -40,8 +43,8 @@ public class Member extends BaseTimeEntity {
 	@Embedded
 	private Email email;
 
-	@Column(name = "password", nullable = false)
-	private String password;
+	@Embedded
+	private EncodedPassword password;
 
 	@Column(name = "name", nullable = false)
 	private String name;
@@ -66,22 +69,17 @@ public class Member extends BaseTimeEntity {
 		this.isPenalty = isPenalty;
 	}
 
-	public static Member create(Email email, String name, String rawPassword, String studentNum,
-		PasswordEncoder passwordEncoder) {
+	public static Member create(Email email, EncodedPassword encodedPassword, String name, String studentNum) {
 		return Member.builder()
 			.email(email)
+			.password(encodedPassword)
 			.name(name)
-			.password(passwordEncoder.encode(rawPassword)) // 비밀번호 해싱
 			.studentNum(studentNum)
 			.roles(List.of("ROLE_USER"))
 			.build();
 	}
 
-	public void changePassword(String encodedPassword) {
-		this.password = encodedPassword;
-	}
-
-	public boolean isPasswordValid(String rawPassword, PasswordEncoder passwordEncoder) {
-		return passwordEncoder.matches(rawPassword, this.password);
+	public void changePassword(EncodedPassword newPassword) {
+		this.password = newPassword;
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/entity/Member.java
@@ -3,12 +3,8 @@ package com.ice.studyroom.domain.membership.domain.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.ice.studyroom.domain.membership.domain.service.encrypt.PasswordEncryptor;
-import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
-import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.global.entity.BaseTimeEntity;
 

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.ice.studyroom.domain.membership.domain.service.encrypt.PasswordEncryptor;
+import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
+import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -24,32 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberDomainService {
 	private final MemberRepository memberRepository;
-	private final PasswordEncoder passwordEncoder;
-	private final VerificationCodeCacheService verificationCodeCacheService;
-
-	public void registerMember(MemberCreateRequest request) {
-		MembershipLogUtil.log("회원 등록 도메인 로직 진입", "email: " + request.email());
-		validateEmailUniqueness(Email.of(request.email()));
-		checkVerification(request.isAuthenticated());
-		validateVerificationCode(request.email(), request.authenticationCode());
-
-		Member member = Member.create(
-			Email.of(request.email()),
-			request.name(),
-			request.password(),
-			request.studentNum(),
-			passwordEncoder
-		);
-
-		memberRepository.save(member);
-	}
-
-	public void validateEmailUniqueness(Email email) {
-		if (memberRepository.existsByEmail(email)) {
-			MembershipLogUtil.logWarn("회원 등록 실패 - 중복 이메일", "email: " + email.getValue());
-			throw new BusinessException(StatusCode.CONFLICT, "이미 사용 중인 이메일입니다.");
-		}
-	}
 
 	public Member getMemberByEmail(String email) {
 		return Optional.ofNullable(memberRepository.getMemberByEmail(Email.of(email)))
@@ -67,13 +44,6 @@ public class MemberDomainService {
 			});
 	}
 
-	public void validatePasswordMatch(Member member, String password){
-		if(!member.isPasswordValid(password, passwordEncoder)){
-			MembershipLogUtil.logWarn("로그인 실패 - 비밀번호 불일치", "email: " + member.getEmail().getValue());
-			throw new BusinessException(StatusCode.BAD_REQUEST, "아이디 혹은 비밀번호가 일치하지 않습니다.");
-		}
-	}
-
 	public String getUserNameByEmail(Email email) {
 		return memberRepository.findByEmail(email)
 			.map(Member::getName)
@@ -81,43 +51,6 @@ public class MemberDomainService {
 				MembershipLogUtil.logWarn("이름 조회 실패 - 존재하지 않는 이메일", "email: " + email.getValue());
 				return new BusinessException(StatusCode.NOT_FOUND, "해당 이메일을 가진 유저는 존재하지 않습니다.");
 			});
-	}
-
-	private void checkVerification(boolean isAuthenticated) {
-		if (!isAuthenticated) {
-			MembershipLogUtil.logWarn("회원 등록 실패 - 이메일 인증 안됨");
-			throw new BusinessException(StatusCode.BAD_REQUEST, "이메일 인증을 진행해주세요.");
-		}
-	}
-
-	private void validateVerificationCode(String email, String authenticationCode) {
-		if (!Objects.equals(verificationCodeCacheService.getVerificationCode(email), authenticationCode)) {
-			MembershipLogUtil.logWarn("회원 등록 실패 - 인증 코드 불일치", "email: " + email);
-			throw new BusinessException(StatusCode.BAD_REQUEST, "인증 코드가 유효하지 않거나 만료되었습니다.");
-		}
-	}
-
-	public void updateMemberPassword(Member member, String currentPassword, String newPassword,
-		String confirmPassword) {
-		String email = member.getEmail().getValue();
-
-		if (!member.isPasswordValid(currentPassword, passwordEncoder)) {
-			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 기존 비밀번호 불일치", "email: " + email);
-			throw new BusinessException(StatusCode.UNAUTHORIZED, "기존 비밀번호가 일치하지 않습니다.");
-		}
-
-		if(newPassword.equals(currentPassword)) {
-			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 새로운 비밀번호가 기존 비밀번호와 동일함", "email: " + email);
-			throw new BusinessException(StatusCode.BAD_REQUEST, "기존 비밀번호와 새로운 비밀번호가 동일합니다.");
-		}
-
-		if (!newPassword.equals(confirmPassword)) {
-			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 새 비밀번호가 일치하지 않음", "email: " + email);
-			throw new BusinessException(StatusCode.BAD_REQUEST, "새로운 비밀번호가 서로 일치하지 않습니다.");
-		}
-
-		member.changePassword(passwordEncoder.encode(newPassword));
-		memberRepository.save(member);
 	}
 
 	public boolean isMemberPenalty(String email) {
@@ -128,5 +61,4 @@ public class MemberDomainService {
 	public List<Member> getMembersByEmail(List<Email> emails){
 		return memberRepository.findByEmailIn(emails);
 	}
-
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/encrypt/PasswordEncryptor.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/encrypt/PasswordEncryptor.java
@@ -1,0 +1,9 @@
+package com.ice.studyroom.domain.membership.domain.service.encrypt;
+
+import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
+import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
+
+public interface PasswordEncryptor {
+	EncodedPassword encrypt(RawPassword rawPassword);
+	boolean matches(RawPassword rawPassword, EncodedPassword encodedPassword);
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/encrypt/PasswordEncryptor.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/encrypt/PasswordEncryptor.java
@@ -4,6 +4,20 @@ import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
 import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
 
 public interface PasswordEncryptor {
+	/**
+	 * 원시 비밀번호(RawPassword)를 암호화(해싱)합니다.
+	 *
+	 * @param rawPassword 암호화할 원시 비밀번호
+	 * @return 암호화된 비밀번호 객체
+	 */
 	EncodedPassword encrypt(RawPassword rawPassword);
+	
+	/**
+	 * 입력된 원시 비밀번호와 저장된 암호화 비밀번호가 일치하는지 확인합니다.
+	 *
+	 * @param rawPassword 사용자가 입력한 원시 비밀번호
+	 * @param encodedPassword 저장된 암호화된 비밀번호
+	 * @return 비밀번호가 일치하면 true, 일치하지 않으면 false
+	 */
 	boolean matches(RawPassword rawPassword, EncodedPassword encodedPassword);
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/encrypt/PasswordEncryptorImpl.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/encrypt/PasswordEncryptorImpl.java
@@ -1,0 +1,24 @@
+package com.ice.studyroom.domain.membership.domain.service.encrypt;
+
+import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
+import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordEncryptorImpl implements PasswordEncryptor {
+
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public EncodedPassword encrypt(RawPassword rawPassword) {
+		return EncodedPassword.of(passwordEncoder.encode(rawPassword.getValue()));
+	}
+
+	@Override
+	public boolean matches(RawPassword rawPassword, EncodedPassword encodedPassword) {
+		return passwordEncoder.matches(rawPassword.getValue(), encodedPassword.getValue());
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/manage/MemberEmailService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/manage/MemberEmailService.java
@@ -1,0 +1,89 @@
+package com.ice.studyroom.domain.membership.domain.service.manage;
+
+import com.ice.studyroom.domain.identity.domain.service.VerificationCodeCacheService;
+import com.ice.studyroom.domain.membership.domain.util.MembershipLogUtil;
+import com.ice.studyroom.domain.membership.domain.vo.Email;
+import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.StatusCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class MemberEmailService {
+
+	private final MemberRepository memberRepository;
+	private final VerificationCodeCacheService verificationCodeCacheService;
+
+	/**
+	 * 회원가입을 위해 이메일 자격을 검증합니다.
+	 * 이메일 인증 여부, 이메일 중복 여부, 인증 코드 유효성을 모두 검증합니다.
+	 *
+	 * @param email               회원가입을 시도하는 사용자의 이메일
+	 * @param isAuthenticated     이메일 인증 완료 여부
+	 * @param authenticationCode  사용자가 입력한 이메일 인증 코드
+	 * @throws BusinessException  인증 실패, 중복 이메일, 인증 코드 불일치 시 예외를 발생시킵니다.
+	 */
+	public void verifyEmailForRegistration(Email email, boolean isAuthenticated, String authenticationCode) {
+		assertEmailAuthenticated(isAuthenticated);
+		ensureEmailIsUnique(email);
+		verifyVerificationCode(email, authenticationCode);
+	}
+
+	/**
+	 * 이메일이 DB에 존재하는지 여부를 검증합니다.
+	 * 외부 서비스에서도 사용할 수 있는 유틸성 메서드입니다.
+	 *
+	 * @param email  중복 여부를 검사할 이메일
+	 * @throws BusinessException  이메일이 이미 존재할 경우 예외를 발생시킵니다.
+	 */
+	public void ensureEmailIsUnique(Email email) {
+		verifyEmailUniqueness(email);
+	}
+
+	/**
+	 * 이메일이 인증되었는지를 검증합니다.
+	 * 인증되지 않은 경우 예외를 발생시킵니다.
+	 *
+	 * @param isAuthenticated  이메일 인증 완료 여부
+	 * @throws BusinessException  이메일이 인증되지 않은 경우 예외를 발생시킵니다.
+	 */
+	private void assertEmailAuthenticated(boolean isAuthenticated) {
+		if (!isAuthenticated) {
+			MembershipLogUtil.logWarn("회원 등록 실패 - 이메일 인증 안됨");
+			throw new BusinessException(StatusCode.BAD_REQUEST, "이메일 인증을 진행해주세요.");
+		}
+	}
+
+	/**
+	 * 내부용 이메일 중복 여부 검증입니다.
+	 * 주로 외부 메서드를 통해 호출됩니다.
+	 *
+	 * @param email  중복 여부를 검사할 이메일
+	 * @throws BusinessException  이미 존재하는 이메일일 경우 예외를 발생시킵니다.
+	 */
+	private void verifyEmailUniqueness(Email email) {
+		if (memberRepository.existsByEmail(email)) {
+			MembershipLogUtil.logWarn("회원 등록 실패 - 중복 이메일", "email: " + email.getValue());
+			throw new BusinessException(StatusCode.CONFLICT, "이미 사용 중인 이메일입니다.");
+		}
+	}
+
+	/**
+	 * 이메일 인증 코드의 일치 여부를 검증합니다.
+	 * 저장된 인증 코드와 사용자가 입력한 인증 코드를 비교합니다.
+	 *
+	 * @param email               인증 코드를 확인할 대상 이메일
+	 * @param authenticationCode  사용자가 입력한 인증 코드
+	 * @throws BusinessException  인증 코드가 유효하지 않거나 만료된 경우 예외를 발생시킵니다.
+	 */
+	private void verifyVerificationCode(Email email, String authenticationCode) {
+		if (!Objects.equals(verificationCodeCacheService.getVerificationCode(email.getValue()), authenticationCode)) {
+			MembershipLogUtil.logWarn("회원 등록 실패 - 인증 코드 불일치", "email: " + email);
+			throw new BusinessException(StatusCode.BAD_REQUEST, "인증 코드가 유효하지 않거나 만료되었습니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/manage/MemberPasswordService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/manage/MemberPasswordService.java
@@ -1,0 +1,101 @@
+package com.ice.studyroom.domain.membership.domain.service.manage;
+
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.service.encrypt.PasswordEncryptor;
+import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
+import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.StatusCode;
+import com.ice.studyroom.domain.membership.domain.util.MembershipLogUtil;
+import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberPasswordService {
+
+	private final PasswordEncryptor passwordEncryptor;
+	private final MemberRepository memberRepository;
+
+	/**
+	 * 회원의 비밀번호를 변경합니다.
+	 * 기존 비밀번호 확인, 새로운 비밀번호의 유효성 검증, 암호화 후 저장까지 수행합니다.
+	 *
+	 * @param member            비밀번호를 변경하려는 회원 엔티티
+	 * @param currentPassword   현재 비밀번호 (입력값)
+	 * @param newPassword       새로 설정할 비밀번호
+	 * @param confirmPassword   새 비밀번호 확인 입력값
+	 * @throws BusinessException  비밀번호 불일치, 동일 비밀번호 재사용, 새 비밀번호 불일치 시 예외를 발생시킵니다.
+	 */
+	public void updateMemberPassword(Member member, RawPassword currentPassword, RawPassword newPassword, RawPassword confirmPassword) {
+		validateCurrentPassword(member, currentPassword);
+		validateNewPasswordDifference(currentPassword, newPassword);
+		validateConfirmationMatch(newPassword, confirmPassword);
+
+		EncodedPassword encoded = passwordEncryptor.encrypt(newPassword);
+		member.changePassword(encoded);
+		memberRepository.save(member);
+	}
+
+	/**
+	 * 로그인 시 입력한 비밀번호가 저장된 비밀번호와 일치하는지 검증합니다.
+	 * 인증 실패 시 예외를 발생시킵니다.
+	 *
+	 * @param member        로그인 시도 중인 회원 엔티티
+	 * @param rawPassword   사용자가 입력한 비밀번호 문자열
+	 * @throws BusinessException  비밀번호가 일치하지 않을 경우 예외를 발생시킵니다.
+	 */
+	public void assertPasswordMatches(Member member, String rawPassword) {
+		RawPassword input = RawPassword.of(rawPassword);
+		if (!passwordEncryptor.matches(input, member.getPassword())) {
+			MembershipLogUtil.logWarn("로그인 실패 - 비밀번호 불일치");
+			throw new BusinessException(StatusCode.BAD_REQUEST, "아이디 혹은 비밀번호가 일치하지 않습니다.");
+		}
+	}
+
+	/**
+	 * 사용자의 현재 비밀번호가 저장된 비밀번호와 일치하는지 검증합니다.
+	 *
+	 * @param member    비밀번호를 변경하려는 회원 엔티티
+	 * @param current   사용자가 입력한 현재 비밀번호
+	 * @throws BusinessException  현재 비밀번호가 일치하지 않을 경우 예외를 발생시킵니다.
+	 */
+	private void validateCurrentPassword(Member member, RawPassword current) {
+		if (!passwordEncryptor.matches(current, member.getPassword())) {
+			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 기존 비밀번호 불일치");
+			throw new BusinessException(StatusCode.UNAUTHORIZED, "기존 비밀번호가 일치하지 않습니다.");
+		}
+	}
+
+	/**
+	 * 현재 비밀번호와 새 비밀번호가 서로 다른지 검증합니다.
+	 * 새 비밀번호가 기존 비밀번호와 같으면 변경을 허용하지 않습니다.
+	 *
+	 * @param current   현재 비밀번호
+	 * @param newPass   새로 설정할 비밀번호
+	 * @throws BusinessException  기존 비밀번호와 새 비밀번호가 동일한 경우 예외를 발생시킵니다.
+	 */
+	private void validateNewPasswordDifference(RawPassword current, RawPassword newPass) {
+		if (current.equals(newPass)) {
+			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 기존의 비밀번호와 새로운 비밀번호 일치");
+			throw new BusinessException(StatusCode.BAD_REQUEST, "기존 비밀번호와 새로운 비밀번호가 동일합니다.");
+		}
+	}
+
+	/**
+	 * 새 비밀번호와 비밀번호 확인 입력값이 일치하는지 검증합니다.
+	 *
+	 * @param newPass   새로 설정할 비밀번호
+	 * @param confirm   새 비밀번호 확인 입력값
+	 * @throws BusinessException  새 비밀번호와 확인 입력값이 일치하지 않을 경우 예외를 발생시킵니다.
+	 */
+	private void validateConfirmationMatch(RawPassword newPass, RawPassword confirm) {
+		if (!newPass.equals(confirm)) {
+			MembershipLogUtil.logWarn("비밀번호 변경 실패 - 새로운 비밀번호 간의 불일치 발생");
+			throw new BusinessException(StatusCode.BAD_REQUEST, "새로운 비밀번호가 서로 일치하지 않습니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/Email.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/Email.java
@@ -18,7 +18,8 @@ public class Email implements Serializable {
 	@Column(name = "email")
 	private String value;
 
-	public Email(String value) {
+	private Email(String value) {
+		validateValue(value);
 		this.value = value;
 	}
 
@@ -27,11 +28,10 @@ public class Email implements Serializable {
 	}
 
 	public static Email of(String value) {
-		validateEmailFormat(value);
 		return new Email(value);
 	}
 
-	private static void validateEmailFormat(String value) {
+	private static void validateValue(String value) {
 		if (!value.endsWith("@hufs.ac.kr")) {
 			throw new BusinessException(StatusCode.BAD_REQUEST, "이메일은 @hufs.ac.kr로 끝나야 합니다.");
 		}
@@ -43,5 +43,10 @@ public class Email implements Serializable {
 		if (!(o instanceof Email)) return false;
 		Email email = (Email) o;
 		return Objects.equals(value, email.value);
+	}
+
+	@Override
+	public String toString() {
+		return value;
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/EncodedPassword.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/EncodedPassword.java
@@ -1,0 +1,40 @@
+package com.ice.studyroom.domain.membership.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EncodedPassword {
+
+	@Column(name = "password", nullable = false)
+	private String value;
+
+	private EncodedPassword(String value) {
+		this.value = value;
+	}
+
+	public static EncodedPassword of(String value) {
+		return new EncodedPassword(value);
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		EncodedPassword that = (EncodedPassword) o;
+		return Objects.equals(value, that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(value);
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/RawPassword.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/RawPassword.java
@@ -41,10 +41,6 @@ public class RawPassword {
 		}
 	}
 
-	public boolean isSamePassword(String otherPassword) {
-		return this.value.equals(otherPassword);
-	}
-
 	@Override
 	public boolean equals(Object o) {
 		if (o == null || getClass() != o.getClass()) return false;

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/RawPassword.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/RawPassword.java
@@ -1,0 +1,61 @@
+package com.ice.studyroom.domain.membership.domain.vo;
+
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.StatusCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RawPassword {
+
+	@Column(name = "password", nullable = false)
+	private String value;
+
+	private RawPassword(String value) {
+		validateValue(value);
+		this.value = value;
+	}
+
+	public static RawPassword of(String value) {
+		return new RawPassword(value);
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	private static void validateValue(String value) {
+		if (value == null || value.isBlank()) {
+			throw new BusinessException(StatusCode.BAD_REQUEST, "비밀번호는 필수 입력 항목입니다.");
+		}
+
+		// 비밀번호 정규식: 소문자 + 숫자 + 특수문자 하나 이상 포함, 8자 이상
+		String passwordRegex = "^(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[a-z\\d@$!%*?&]{8,}$";
+
+		if (!value.matches(passwordRegex)) {
+			throw new BusinessException(StatusCode.BAD_REQUEST,
+				"비밀번호는 최소 8자 이상, 하나 이상의 소문자, 숫자 및 특수 문자를 포함해야 합니다.");
+		}
+	}
+
+	public boolean isSamePassword(String otherPassword) {
+		return this.value.equals(otherPassword);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		RawPassword that = (RawPassword) o;
+		return Objects.equals(value, that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(value);
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/RawPassword.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/vo/RawPassword.java
@@ -3,13 +3,11 @@ package com.ice.studyroom.domain.membership.domain.vo;
 import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.type.StatusCode;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.util.Objects;
 
-@Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RawPassword {
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -615,7 +615,7 @@ public class ReservationService {
 		Schedule schedule) {
 
 		String subject = "[ICE-STUDYRES] 스터디룸 예약이 완료되었습니다.";
-		List<Email> participantsEmailList = participantsEmail.stream().map(Email::new).toList();
+		List<Email> participantsEmailList = participantsEmail.stream().map(Email::of).toList();
 		String body = buildReservationSuccessEmailBody(type, schedule, reservationOwnerEmail, participantsEmailList);
 
 		emailService.sendEmail(new EmailRequest(reservationOwnerEmail, subject, body));

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/GroupReservationTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/GroupReservationTest.java
@@ -728,12 +728,12 @@ public class GroupReservationTest {
 
 	void 예약자_존재확인(){
 		given(tokenService.extractEmailFromAccessToken(token)).willReturn(ownerEmail);
-		given(memberRepository.findByEmail(new Email(ownerEmail))).willReturn(Optional.of(reservationOwner));
+		given(memberRepository.findByEmail(Email.of(ownerEmail))).willReturn(Optional.of(reservationOwner));
 	}
 
 	void 비패널티_예약자_존재확인(){
 		given(tokenService.extractEmailFromAccessToken(token)).willReturn(ownerEmail);
-		given(memberRepository.findByEmail(new Email(ownerEmail))).willReturn(Optional.of(reservationOwner));
+		given(memberRepository.findByEmail(Email.of(ownerEmail))).willReturn(Optional.of(reservationOwner));
 		given(reservationOwner.isPenalty()).willReturn(false);
 	}
 


### PR DESCRIPTION
## PR 종류
- [x] 리팩토링


## 변경 사항

- 비밀번호를 값 객체로 변환함에 따른 자기 유효성 검사 가능 및 비즈니스 로직 간소화
- MemberPasswordService, MemberEmailService, PasswordEncryptor 과 같은 도메인 레이어를 구현함에 따른 객체 간의 협력 레이어 구현
- 어플리케이션 레이어는 흐름만 작성하도록 수정
- 도메인 서비스 메서드 명을 어플리케이션애서 사용하는데 있어 개발 생산성을 늘리기 위해 메서드 컨벤션 설정

## 관련 이슈

- #484 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

### 비밀번호 유효성 검증 - RawPassword, EncodedPassword 의 도입
현재 비밀번호 검증은 DTO에서만 Valid로 검증되고 있습니다. 다만 비즈니스 로직에서 생성되는 email이나 데이터는 검증되지않은 채로 생성될 수 있다는 위험이 있습니다.
따라서 비밀번호 VO를 생성해서 유효성 검증이 가능하며 더 나아가 Entity에 컬럼으로 적용될 수 있게 하였습니다.

### RawPassword(평문), EncodedPassword(암호문) 로 나눈 이유
비밀번호는 평문과 암호문 이렇게 2개의 상태가 존재합니다.
비밀번호 유효성 검증은 오직 평문인 상태에서만 검증이 가능합니다. 그러나 우리가 직접 데이터 베이스에 저장하는 데이터는 암호화된 비밀번호입니다. 이에 따라 비밀번호 VO를 암호화 여부에 따른 데이터로 구분했습니다.

따라서 유효성 검증 및 비밀번호 비교는 RawPassword가 관리합니다.
```java
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class RawPassword {

	@Column(name = "password", nullable = false)
	private String value;

	private RawPassword(String value) {
		validateValue(value);
		this.value = value;
	}

	public static RawPassword of(String value) {
		return new RawPassword(value);
	}

	public String getValue() {
		return value;
	}

	private static void validateValue(String value) {
		if (value == null || value.isBlank()) {
			throw new BusinessException(StatusCode.BAD_REQUEST, "비밀번호는 필수 입력 항목입니다.");
		}

		// 비밀번호 정규식: 소문자 + 숫자 + 특수문자 하나 이상 포함, 8자 이상
		String passwordRegex = "^(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[a-z\\d@$!%*?&]{8,}$";

		if (!value.matches(passwordRegex)) {
			throw new BusinessException(StatusCode.BAD_REQUEST,
				"비밀번호는 최소 8자 이상, 하나 이상의 소문자, 숫자 및 특수 문자를 포함해야 합니다.");
		}
	}

	@Override
	public boolean equals(Object o) {
		if (o == null || getClass() != o.getClass()) return false;
		RawPassword that = (RawPassword) o;
		return Objects.equals(value, that.value);
	}

	@Override
	public int hashCode() {
		return Objects.hashCode(value);
	}
}
```
암호화된 비밀번호의 값 객체는 EncodedPassword를 통해서 관리합니다.
```java
@Embeddable
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class EncodedPassword {

	@Column(name = "password", nullable = false)
	private String value;

	private EncodedPassword(String value) {
		this.value = value;
	}

	public static EncodedPassword of(String value) {
		return new EncodedPassword(value);
	}

	public String getValue() {
		return value;
	}

	@Override
	public boolean equals(Object o) {
		if (o == null || getClass() != o.getClass()) return false;
		EncodedPassword that = (EncodedPassword) o;
		return Objects.equals(value, that.value);
	}

	@Override
	public int hashCode() {
		return Objects.hashCode(value);
	}
}
```
### RawPassword, EncodedPassword를 관리하는 유틸 객체 PasswordEncryptor
평문 비밀번호를 암호화된 비밀번호로 변경하거나 사용자의 비밀번호를 로그인 시에 검증하는 로직을 수행하는  
즉 VO 간의 협력이 가능한 공간을 만들었습니다.
```java
@Service
@RequiredArgsConstructor
public class PasswordEncryptorImpl implements PasswordEncryptor {

	private final PasswordEncoder passwordEncoder;

	@Override
	public EncodedPassword encrypt(RawPassword rawPassword) {
		return EncodedPassword.of(passwordEncoder.encode(rawPassword.getValue()));
	}

	@Override
	public boolean matches(RawPassword rawPassword, EncodedPassword encodedPassword) {
		return passwordEncoder.matches(rawPassword.getValue(), encodedPassword.getValue());
	}
}
```

### Email, Password 간의 비즈니스 로직을 담은 도메인 서비스 레이어 구축
이외 Email과 Password의 협력에 필요한 순수한 비즈니스 로직은 각 도메인 서비스로 분할해주었습니다.
- MemberEmailService
- MemberPasswordService

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
