### PR TITLE
[BE-#486] 이메일 예약 이용 시간 버그 수정

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/service/MemberDomainService.java
@@ -1,21 +1,14 @@
 package com.ice.studyroom.domain.membership.domain.service;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
-import com.ice.studyroom.domain.membership.domain.service.encrypt.PasswordEncryptor;
-import com.ice.studyroom.domain.membership.domain.vo.EncodedPassword;
-import com.ice.studyroom.domain.membership.domain.vo.RawPassword;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import com.ice.studyroom.domain.identity.domain.service.VerificationCodeCacheService;
 import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.membership.domain.util.MembershipLogUtil;
 import com.ice.studyroom.domain.membership.domain.vo.Email;
 import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
-import com.ice.studyroom.domain.membership.presentation.dto.request.MemberCreateRequest;
 import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.type.StatusCode;
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -137,10 +137,10 @@ public class ReservationService {
 				return new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 예약입니다.");
 			});
 
-		// if(reservation.getStatus() != ReservationStatus.RESERVED){
-		// 	ReservationLogUtil.logWarn("QR코드 요청 실패 - 예약 상태 아님", "예약 ID: " + reservationId);
-		// 	throw new BusinessException(StatusCode.BAD_REQUEST, "예약 상태가 아닙니다.");
-		// }
+		if(reservation.getStatus() != ReservationStatus.RESERVED){
+			ReservationLogUtil.logWarn("QR코드 요청 실패 - 예약 상태 아님", "예약 ID: " + reservationId);
+			throw new BusinessException(StatusCode.BAD_REQUEST, "예약 상태가 아닙니다.");
+		}
 
 		// 해당 사용자의 예약인지 확인
 		if (!reservation.isOwnedBy(reservationOwnerEmail)) {

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -279,7 +279,7 @@ public class ReservationService {
 
 		scheduleRepository.saveAll(schedules);
 		ReservationLogUtil.log("개인 예약 생성 성공", "예약자: " + reservationOwnerEmail, "예약 ID: " + reservation.getId());
-		sendReservationSuccessEmail(roomType, reservationOwnerEmail, new HashSet<>(), schedules.get(0));
+		sendReservationSuccessEmail(roomType, reservationOwnerEmail, new HashSet<>(), schedules);
 
 		return "Success";
 	}
@@ -396,7 +396,7 @@ public class ReservationService {
 		ReservationLogUtil.log("단체 예약 생성 성공", "예약자: " + reservationOwnerEmail, "참여자 수: " + (uniqueEmails.size()-1), "예약 ID: " + reservations.get(0).getId());
 
 		//전 인원에게 예약 확정 메일 발송
-		sendReservationSuccessEmail(roomType, reservationOwnerEmail, uniqueEmails, schedules.get(0));
+		sendReservationSuccessEmail(roomType, reservationOwnerEmail, uniqueEmails, schedules);
 
 		return "Success";
 	}
@@ -612,11 +612,11 @@ public class ReservationService {
 	}
 
 	protected void sendReservationSuccessEmail(RoomType type, String reservationOwnerEmail, Set<String> participantsEmail,
-		Schedule schedule) {
+		List<Schedule> schedules) {
 
 		String subject = "[ICE-STUDYRES] 스터디룸 예약이 완료되었습니다.";
 		List<Email> participantsEmailList = participantsEmail.stream().map(Email::of).toList();
-		String body = buildReservationSuccessEmailBody(type, schedule, reservationOwnerEmail, participantsEmailList);
+		String body = buildReservationSuccessEmailBody(type, schedules, reservationOwnerEmail, participantsEmailList);
 
 		emailService.sendEmail(new EmailRequest(reservationOwnerEmail, subject, body));
 
@@ -629,7 +629,7 @@ public class ReservationService {
 		}
 	}
 
-	private String buildReservationSuccessEmailBody(RoomType type, Schedule schedule, String reservationOwnerEmail, List<Email> participantsEmail) {
+	private String buildReservationSuccessEmailBody(RoomType type, List<Schedule> schedules, String reservationOwnerEmail, List<Email> participantsEmail) {
 		String participantsSection = "";
 		Member reservationOwner = memberDomainService.getMemberByEmail(reservationOwnerEmail);
 		List<Member> participantsMember = memberDomainService.getMembersByEmail(participantsEmail);
@@ -667,10 +667,10 @@ public class ReservationService {
 				"</body></html>",
 			reservationOwner.getName(),
 			reservationOwner.getStudentNum(),
-			schedule.getRoomNumber(),
+			schedules.get(0).getRoomNumber(),
 			LocalDate.now(),
-			schedule.getStartTime(),
-			schedule.getEndTime(),
+			schedules.get(0).getStartTime(),
+			schedules.size() > 1 ? schedules.get(1).getEndTime() : schedules.get(0).getEndTime(),
 			participantsSection
 		);
 	}

--- a/frontend/src/pages/Mainpage/handlers/MemberHandlers.jsx
+++ b/frontend/src/pages/Mainpage/handlers/MemberHandlers.jsx
@@ -188,7 +188,9 @@ export const useMemberHandlers = () => {
                 }
             }
         } catch (error) {
-            const errorMessage = error.response?.data?.message || '로그인 중 오류가 발생했습니다.';
+            //todo: 에러 메시지 처리
+            //const errorMessage = error.response?.data?.message || '로그인 중 오류가 발생했습니다.';
+            const errorMessage = '아이디 혹은 비밀번호가 일치하지 않습니다.';
             setLoginError(errorMessage);
         }
     };


### PR DESCRIPTION
## PR 종류
- [x] 기능 개선

## 변경 사항
-  2시간의 예약을 진행했을경우, 종료 시간이 1시간의 예약만 반영되었던 버그를 수정했습니다.
- 로그인 실패 메시지가 상세한 것 같습니다. (회원가입 로직과 동일) 그래서 에러메시지를 우선 `아이디 혹은 비밀번호가 일치하지 않습니다.` 로 수정해두었습니다. 
  <img width="470" alt="image" src="https://github.com/user-attachments/assets/d650c483-3800-4508-a22d-874f8af3177c" />
## 관련 이슈

- #486 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용


## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
