### PR TITLE
[BE-#490] 관리자의 방 정보 조회 및 방 타입 변경 기능 구현

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
@@ -186,4 +186,11 @@ public class AdminService {
 	public List<RoomInfoResponse> adminGetRoomInfo() {
 		return roomTimeSlotRepository.findDistinctRoomInfo();
 	}
+
+	@Transactional
+	public String adminModRoomType(String roomNumber, AdminModRoomTypeRequest request) {
+		roomModificationService.changeRoomType(roomNumber, request.roomType());
+		AdminLogUtil.log("방 상태 변경", "방 번호: " + roomNumber);
+		return "방 상태 반환 성공";
+	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/application/AdminService.java
@@ -1,11 +1,9 @@
 package com.ice.studyroom.domain.admin.application;
 
+import com.ice.studyroom.domain.admin.domain.service.manage.RoomModificationService;
 import com.ice.studyroom.domain.admin.domain.type.DayOfWeekStatus;
 import com.ice.studyroom.domain.admin.domain.util.AdminLogUtil;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminDelPenaltyRequest;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminOccupyRequest;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminReleaseRequest;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminSetPenaltyRequest;
+import com.ice.studyroom.domain.admin.presentation.dto.request.*;
 import com.ice.studyroom.domain.admin.presentation.dto.response.*;
 import com.ice.studyroom.domain.membership.domain.entity.Member;
 import com.ice.studyroom.domain.penalty.application.PenaltyService;
@@ -36,6 +34,7 @@ import java.util.List;
 public class AdminService {
 
 	private final RoomTimeSlotRepository roomTimeSlotRepository;
+	private final RoomModificationService roomModificationService;
 	private final PenaltyRepository penaltyRepository;
 	private final ScheduleRepository scheduleRepository;
 	private final MemberRepository memberRepository;
@@ -182,5 +181,9 @@ public class AdminService {
 		penaltyService.adminDeletePenalty(member);
 		AdminLogUtil.log("패널티 해제 완료", "학번: " + request.studentNum());
 		return "패널티 해제가 완료되었습니다.";
+	}
+
+	public List<RoomInfoResponse> adminGetRoomInfo() {
+		return roomTimeSlotRepository.findDistinctRoomInfo();
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/domain/service/manage/RoomModificationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/domain/service/manage/RoomModificationService.java
@@ -4,7 +4,7 @@ import com.ice.studyroom.domain.admin.domain.service.policy.RoomPolicyService;
 import com.ice.studyroom.domain.admin.domain.type.RoomType;
 import com.ice.studyroom.domain.admin.domain.util.AdminLogUtil;
 import com.ice.studyroom.domain.admin.infrastructure.persistence.RoomTimeSlotRepository;
-import com.ice.studyroom.global.exception.jwt.RoomNotFoundException;
+import com.ice.studyroom.global.exception.RoomNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/domain/service/manage/RoomModificationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/domain/service/manage/RoomModificationService.java
@@ -1,0 +1,26 @@
+package com.ice.studyroom.domain.admin.domain.service.manage;
+
+import com.ice.studyroom.domain.admin.domain.service.policy.RoomPolicyService;
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+import com.ice.studyroom.domain.admin.domain.util.AdminLogUtil;
+import com.ice.studyroom.domain.admin.infrastructure.persistence.RoomTimeSlotRepository;
+import com.ice.studyroom.global.exception.jwt.RoomNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomModificationService {
+
+	private final RoomTimeSlotRepository roomTimeSlotRepository;
+	private final RoomPolicyService roomPolicyService;
+
+	public void changeRoomType(String roomNumber, RoomType type) {
+		int minRes = roomPolicyService.getMinResByRoomType(type);
+		int updated = roomTimeSlotRepository.updateRoomTypeAndMinRes(roomNumber, type, minRes);
+		if (updated == 0) {
+			AdminLogUtil.logWarn("수정하려는 방의 정보를 찾을 수 없습니다.", "방 번호: " + roomNumber);
+			throw new RoomNotFoundException(roomNumber);
+		}
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/domain/service/policy/RoomPolicyService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/domain/service/policy/RoomPolicyService.java
@@ -1,0 +1,15 @@
+package com.ice.studyroom.domain.admin.domain.service.policy;
+
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoomPolicyService {
+
+	public int getMinResByRoomType(RoomType roomType) {
+		return switch (roomType) {
+			case INDIVIDUAL -> 1;
+			case GROUP -> 2;
+		};
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/infrastructure/persistence/RoomTimeSlotRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/infrastructure/persistence/RoomTimeSlotRepository.java
@@ -2,15 +2,25 @@ package com.ice.studyroom.domain.admin.infrastructure.persistence;
 
 import com.ice.studyroom.domain.admin.domain.entity.RoomTimeSlot;
 import com.ice.studyroom.domain.admin.domain.type.DayOfWeekStatus;
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+import com.ice.studyroom.domain.admin.presentation.dto.response.RoomInfoResponse;
 import com.ice.studyroom.domain.reservation.domain.type.ScheduleSlotStatus;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface RoomTimeSlotRepository extends JpaRepository<RoomTimeSlot, Long> {
 
 	List<RoomTimeSlot> findByStatus(ScheduleSlotStatus status);
-
 	List<RoomTimeSlot> findByDayOfWeek(DayOfWeekStatus dayOfWeekStatus);
-}
+
+	@Query("""
+    SELECT DISTINCT new com.ice.studyroom.domain.admin.presentation.dto.response.RoomInfoResponse(r.roomNumber, r.roomType, r.capacity)
+    FROM RoomTimeSlot r
+""")
+	List<RoomInfoResponse> findDistinctRoomInfo();
+ }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/infrastructure/persistence/RoomTimeSlotRepository.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/infrastructure/persistence/RoomTimeSlotRepository.java
@@ -23,4 +23,17 @@ public interface RoomTimeSlotRepository extends JpaRepository<RoomTimeSlot, Long
     FROM RoomTimeSlot r
 """)
 	List<RoomInfoResponse> findDistinctRoomInfo();
+
+	@Modifying(clearAutomatically = true)
+	@Query("""
+    UPDATE RoomTimeSlot r
+    SET r.roomType = :roomType,
+        r.minRes = :minRes
+    WHERE r.roomNumber = :roomNumber
+""")
+	int updateRoomTypeAndMinRes(
+		@Param("roomNumber") String roomNumber,
+		@Param("roomType") RoomType roomType,
+		@Param("minRes") int minRes
+	);
  }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/controller/AdminController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/controller/AdminController.java
@@ -148,7 +148,7 @@ public class AdminController {
 	@PatchMapping("/room-time-slots/room-number/{roomNumber}")
 	public ResponseEntity<ResponseDto<String>> adminModifyRoomType(
 		@PathVariable String roomNumber,
-		@Valid @RequestBody AdminModRoomType request
+		@Valid @RequestBody AdminModRoomTypeRequest request
 	) {
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/controller/AdminController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/controller/AdminController.java
@@ -3,10 +3,7 @@ package com.ice.studyroom.domain.admin.presentation.controller;
 
 import com.ice.studyroom.domain.admin.application.AdminService;
 import com.ice.studyroom.domain.admin.domain.type.DayOfWeekStatus;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminDelPenaltyRequest;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminOccupyRequest;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminReleaseRequest;
-import com.ice.studyroom.domain.admin.presentation.dto.request.AdminSetPenaltyRequest;
+import com.ice.studyroom.domain.admin.presentation.dto.request.*;
 import com.ice.studyroom.domain.admin.presentation.dto.response.*;
 import com.ice.studyroom.global.dto.response.ResponseDto;
 
@@ -126,5 +123,35 @@ public class AdminController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(ResponseDto.of(adminService.adminDelPenalty(request)));
+	}
+
+	@Operation(
+		summary = "방의 RoomNumber, RoomType, capacity 정보 조회",
+		description = "방의 RoomNumber, RoomType, capacity 정보 조회를 할 수 있습니다." +
+			"모든 요일의 방을 정보를 전달해주는 것이 아닌 방 번호 기준으로 전달됩니다."
+	)
+	@ApiResponse(responseCode = "200", description = "요일 구분없이 방에 대한 정보 조회 성공")
+	@ApiResponse(responseCode = "500", description = "요일 구분없이 방에 대한 정보 조회 성공")
+	@GetMapping("/rooms")
+	public ResponseEntity<ResponseDto<List<RoomInfoResponse>>> getRoomInfo() {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ResponseDto.of(adminService.adminGetRoomInfo()));
+	}
+
+	@Operation(
+		summary = "방의 RoomType(예약 단위) 변경",
+		description = "방의 RoomType(예약 단위)를 변경할 수 있습니다. ex) 개인 -> 단체, 단체 -> 개인"
+	)
+	@ApiResponse(responseCode = "200", description = "방 예약 단위 변경 성공")
+	@ApiResponse(responseCode = "500", description = "방 예약 단위 변경 실패")
+	@PatchMapping("/room-time-slots/room-number/{roomNumber}")
+	public ResponseEntity<ResponseDto<String>> adminModifyRoomType(
+		@PathVariable String roomNumber,
+		@Valid @RequestBody AdminModRoomType request
+	) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ResponseDto.of(adminService.adminModRoomType(roomNumber, request)));
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/request/AdminModRoomTypeRequest.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/request/AdminModRoomTypeRequest.java
@@ -1,0 +1,5 @@
+package com.ice.studyroom.domain.admin.presentation.dto.request;
+
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+
+public record AdminModRoomTypeRequest(RoomType roomType) {}

--- a/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/response/RoomInfoResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/admin/presentation/dto/response/RoomInfoResponse.java
@@ -1,0 +1,6 @@
+package com.ice.studyroom.domain.admin.presentation.dto.response;
+
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+
+public record RoomInfoResponse(String roomNumber, RoomType roomType, int capacity) {}
+

--- a/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import com.ice.studyroom.global.dto.response.ResponseDto;
 import com.ice.studyroom.global.type.StatusCode;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 @Slf4j
@@ -71,6 +72,17 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.status(ex.getStatusCode().getStatus())
 			.body(ResponseDto.error(ex.getStatusCode(), ex.getMessage()));
+	}
+
+	// 메세지 컨버팅 실패 예외 처리
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	protected ResponseEntity<ResponseDto<Object>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+		log.warn("TypeMismatchException caught: {}", ex.getMessage());
+		StatusCode status = StatusCode.BAD_REQUEST;
+		String message = String.format("DTO 파라미터 값 '%s'는 허용되지 않는 값입니다.", ex.getValue());
+		return ResponseEntity
+			.status(status.getStatus())
+			.body(ResponseDto.error(status, message));
 	}
 
 	// 일반 예외 처리

--- a/backend/src/main/java/com/ice/studyroom/global/exception/RoomNotFoundException.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/RoomNotFoundException.java
@@ -1,6 +1,5 @@
-package com.ice.studyroom.global.exception.jwt;
+package com.ice.studyroom.global.exception;
 
-import com.ice.studyroom.global.exception.BusinessException;
 import com.ice.studyroom.global.type.StatusCode;
 
 public class RoomNotFoundException extends BusinessException {

--- a/backend/src/main/java/com/ice/studyroom/global/exception/jwt/RoomNotFoundException.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/jwt/RoomNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ice.studyroom.global.exception.jwt;
+
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.StatusCode;
+
+public class RoomNotFoundException extends BusinessException {
+	public RoomNotFoundException(String roomNumber) {
+		super(StatusCode.NOT_FOUND, "roomNumber '" + roomNumber + "'에 해당하는 방이 존재하지 않습니다.");
+	}
+}


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능

## 변경 사항
- 이제 관리자가 프론트를 통해 특정 방의 '단체 예약' 과 '개인 예약' 을 직접 변경할 수 있습니다.

## 관련 이슈

- #490 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
### 구현된 API (프리뷰)
```java
@RestController
@RequiredArgsConstructor
@RequestMapping("/api/admin")
public class AdminController {

	private final AdminService adminService;

        // 코드 생략

	@Operation(
		summary = "방의 RoomNumber, RoomType, capacity 정보 조회",
		description = "방의 RoomNumber, RoomType, capacity 정보 조회를 할 수 있습니다." +
			"모든 요일의 방을 정보를 전달해주는 것이 아닌 방 번호 기준으로 전달됩니다."
	)
	@ApiResponse(responseCode = "200", description = "요일 구분없이 방에 대한 정보 조회 성공")
	@ApiResponse(responseCode = "500", description = "요일 구분없이 방에 대한 정보 조회 성공")
	@GetMapping("/rooms")
	public ResponseEntity<ResponseDto<List<RoomInfoResponse>>> getRoomInfo() {
		return ResponseEntity
			.status(HttpStatus.OK)
			.body(ResponseDto.of(adminService.adminGetRoomInfo()));
	}

	@Operation(
		summary = "방의 RoomType(예약 단위) 변경",
		description = "방의 RoomType(예약 단위)를 변경할 수 있습니다. ex) 개인 -> 단체, 단체 -> 개인"
	)
	@ApiResponse(responseCode = "200", description = "방 예약 단위 변경 성공")
	@ApiResponse(responseCode = "500", description = "방 예약 단위 변경 실패")
	@PatchMapping("/room-time-slots/room-number/{roomNumber}")
	public ResponseEntity<ResponseDto<String>> adminModifyRoomType(
		@PathVariable String roomNumber,
		@Valid @RequestBody AdminModRoomTypeRequest request
	) {
		return ResponseEntity
			.status(HttpStatus.OK)
			.body(ResponseDto.of(adminService.adminModRoomType(roomNumber, request)));
	}
}
```

### 방 타입을 변경하기 위한 조회용 API 구현
```java
public interface RoomTimeSlotRepository extends JpaRepository<RoomTimeSlot, Long> {
	@Query("""
    SELECT DISTINCT new com.ice.studyroom.domain.admin.presentation.dto.response.RoomInfoResponse(r.roomNumber, r.roomType, r.capacity)
    FROM RoomTimeSlot r
""")
	List<RoomInfoResponse> findDistinctRoomInfo();
    // 코드 생략
}
```
- 방을 요일 별로 구분해서 조회하는 것이 아닌, 방 번호를 기준으로 조회해야하기에 DISTINCT를 사용하여 방 번호 별로 정보를 조회하게 구현하였습니다.

### 방 정보 조회 API 호출
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/619bd628-16e1-4882-b3b2-ce5be2c0dc4b" />

### 방 타입 변경 API 구현
```java
@Service
@RequiredArgsConstructor
public class RoomModificationService {

	private final RoomTimeSlotRepository roomTimeSlotRepository;
	private final RoomPolicyService roomPolicyService;

	public void changeRoomType(String roomNumber, RoomType type) {
		int minRes = roomPolicyService.getMinResByRoomType(type);
		int updated = roomTimeSlotRepository.updateRoomTypeAndMinRes(roomNumber, type, minRes);
		if (updated == 0) {
			AdminLogUtil.logWarn("수정하려는 방의 정보를 찾을 수 없습니다.", "방 번호: " + roomNumber);
			throw new RoomNotFoundException(roomNumber);
		}
	}
}

@Service
public class RoomPolicyService {

	public int getMinResByRoomType(RoomType roomType) {
		return switch (roomType) {
			case INDIVIDUAL -> 1;
			case GROUP -> 2;
		};
	}
}
````
- 방 타입을 변경함에 따라 최소예약인원 변경도 필요합니다.
- 단체 예약의 경우 최소 예약 인원은 2명, 개인 예약의 경우 최소 예약 인원은 1명으로 변경하게 하였습니다.
  - 이것은 정책 변경에 따라 변경될 수 있습니다.

### 방 타입 변경 API 호출
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/a1f178b7-ee97-4b1e-83a3-333b0171652d" />  

- GROUP -> INDIVIDUAL 로 변경

### 방 타입 변경이 되지 않는 경우 예외 처리
```java
public class RoomNotFoundException extends BusinessException {
	public RoomNotFoundException(String roomNumber) {
		super(StatusCode.NOT_FOUND, "roomNumber '" + roomNumber + "'에 해당하는 방이 존재하지 않습니다.");
	}
}
```
- 프론트에서 노출되는 방은 테이블에 무조건 존재해야하기 때문에 커스텀 예외를 추가하였습니다.


## 기타
- 추가로 알려야 할 사항이 있다면 적어주세요.
