### PR TITLE
[BE-#500] 개인 예약, 그룹 예약 락 서비스 로직 수행 간에 발생하는 문제 해결

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationCompensationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationCompensationService.java
@@ -1,0 +1,39 @@
+package com.ice.studyroom.domain.reservation.application;
+
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ScheduleRepository;
+import com.ice.studyroom.domain.reservation.util.ReservationLogUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReservationCompensationService {
+
+	private final ScheduleRepository scheduleRepository;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void rollbackSchedules(List<Long> scheduleIds, String email) {
+		List<Long> sortedScheduleIds = new ArrayList<>(scheduleIds);
+		Collections.sort(sortedScheduleIds);
+
+		List<Schedule> schedules = scheduleRepository.findByIdsWithPessimisticLock(sortedScheduleIds);
+
+		for (Schedule schedule : schedules) {
+			// 개인 예약을 위해 +1 했던 currentRes를 되돌림
+			schedule.cancel();
+		}
+
+		scheduleRepository.saveAll(schedules);
+		ReservationLogUtil.log("보상 트랜잭션 수행 완료", "예약자: " + email, "롤백된 스케줄 ID: " + scheduleIds);
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationConcurrencyService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationConcurrencyService.java
@@ -1,0 +1,123 @@
+package com.ice.studyroom.domain.reservation.application;
+
+import com.ice.studyroom.domain.admin.domain.type.RoomType;
+import com.ice.studyroom.domain.membership.domain.vo.Email;
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
+import com.ice.studyroom.domain.reservation.domain.service.ReservationValidator;
+import com.ice.studyroom.domain.reservation.domain.type.ScheduleSlotStatus;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ScheduleRepository;
+import com.ice.studyroom.domain.reservation.util.ReservationLogUtil;
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.StatusCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.PessimisticLockException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReservationConcurrencyService {
+
+	private final ScheduleRepository scheduleRepository;
+	private final ReservationValidator reservationValidator;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public List<Schedule> processIndividualReservationWithLock(List<Long> scheduleIds){
+		try {
+			List<Long> sortedScheduleIds = new ArrayList<>(scheduleIds);
+			Collections.sort(sortedScheduleIds);
+
+			List<Schedule> lockedSchedules = scheduleRepository.findByIdsWithPessimisticLock(sortedScheduleIds);
+
+			if (lockedSchedules.size() != scheduleIds.size()) {
+				ReservationLogUtil.logWarn("개인 예약 실패 - 존재하지 않는 스케줄 포함됨", "스케줄 ID: " + scheduleIds);
+				throw new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄이 포함되어 있습니다.");
+			}
+
+			RoomType roomType = lockedSchedules.get(0).getRoomType();
+			if (roomType == RoomType.GROUP) {
+				ReservationLogUtil.logWarn("개인 예약 실패 - 그룹 전용 방 예약 시도",
+					"방 번호: " + lockedSchedules.get(0).getRoomNumber());
+				throw new BusinessException(StatusCode.FORBIDDEN, "해당 방은 단체예약 전용입니다.");
+			}
+
+			// 스케줄 업데이트 (currentRes 증가 및 상태 변경)
+			for (Schedule schedule : lockedSchedules) {
+				if (!schedule.isCurrentResLessThanCapacity()) {
+					ReservationLogUtil.logWarn("개인 예약 실패 - 수용 인원 초과", "스케줄 ID: " + schedule.getId());
+					throw new BusinessException(StatusCode.BAD_REQUEST, "예약 가능한 자리가 없습니다.");
+				}
+
+				schedule.reserve(); // 개인예약은 현재사용인원에서 +1 진행
+				if (schedule.getCurrentRes().equals(schedule.getCapacity())) { //예약 후 현재인원 == 방수용인원 경우 RESERVE
+					schedule.updateStatus(ScheduleSlotStatus.RESERVED);
+				}
+			}
+			scheduleRepository.saveAll(lockedSchedules);
+			return lockedSchedules;
+		} catch (PessimisticLockException e) {
+			throw new BusinessException(StatusCode.CONFLICT,
+				"현재 예약이 집중되고 있습니다. 잠시 후 다시 시도해주세요.");
+		}
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public List<Schedule> processGroupReservationWithLock(List<Long> scheduleIds, Set<String> uniqueEmails){
+		try{
+			List<Long> sortedScheduleIds = new ArrayList<>(scheduleIds);
+			Collections.sort(sortedScheduleIds);
+
+			List<Schedule> lockedSchedules = scheduleRepository.findByIdsWithPessimisticLock(sortedScheduleIds);
+
+			if (lockedSchedules.size() != scheduleIds.size()) {
+				ReservationLogUtil.logWarn("단체 예약 실패 - 존재하지 않는 스케줄 포함됨", "스케줄 ID: " + scheduleIds);
+				throw new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄이 포함되어 있습니다.");
+			}
+
+			//임계 영역에서 중복 예약 검사
+			for (String email : uniqueEmails) {
+				reservationValidator.checkDuplicateReservation(Email.of(email));
+			}
+
+			reservationValidator.validateSchedulesAvailable(lockedSchedules);
+
+			RoomType roomType = lockedSchedules.get(0).getRoomType();
+			if(roomType == RoomType.INDIVIDUAL) {
+				ReservationLogUtil.logWarn("단체 예약 실패 - 개인 전용 방 예약 시도", "방 번호: " + lockedSchedules.get(0).getRoomNumber());
+				throw new BusinessException(StatusCode.FORBIDDEN, "해당 방은 개인예약 전용입니다.");
+			}
+
+			// 최소 예약 인원(minRes) 검사 (예약자 + 참여자 수 체크)
+			int totalParticipants = uniqueEmails.size(); // 예약자 + 참여자 수
+			int minRes = lockedSchedules.get(0).getMinRes(); // 모든 Group 전용 schedule의 min_res는 2로 동일
+			int capacity = lockedSchedules.get(0).getCapacity(); // 같은 방의 schedule은 capacity는 동일
+			if (totalParticipants < minRes) {
+				ReservationLogUtil.logWarn("단체 예약 실패 - 최소 인원 미달", "최소 인원: " + minRes, "현재 인원: " + totalParticipants);
+				throw new BusinessException(StatusCode.BAD_REQUEST,
+					"최소 예약 인원 조건을 만족하지 않습니다. (필요 인원: " + minRes + ", 현재 인원: " + totalParticipants + ")");
+			}else if (totalParticipants > capacity) {
+				ReservationLogUtil.logWarn("단체 예약 실패 - 최대 인원 초과", "최대 수용 인원: " + capacity, "현재 인원: " + totalParticipants);
+				throw new BusinessException(StatusCode.BAD_REQUEST,
+					"방의 최대 수용 인원을 초과했습니다. (최대 수용 인원: " + capacity + ", 현재 인원: " + totalParticipants + ")");
+			}
+
+			for (Schedule schedule : lockedSchedules) {
+				schedule.updateGroupCurrentRes(totalParticipants); // 현재 사용 인원을 예약자 + 참여자 숫자로 지정
+				schedule.updateStatus(ScheduleSlotStatus.RESERVED);
+			}
+
+			return lockedSchedules;
+		}catch (PessimisticLockException e) {
+			throw new BusinessException(StatusCode.CONFLICT,
+				"현재 예약이 집중되고 있습니다. 잠시 후 다시 시도해주세요.");
+		}
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -13,9 +13,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hibernate.PessimisticLockException;
+import com.ice.studyroom.domain.reservation.domain.service.ReservationValidator;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 
@@ -62,6 +61,8 @@ public class ReservationService {
 	private final MemberRepository memberRepository;
 	private final ReservationRepository reservationRepository;
 	private final ScheduleRepository scheduleRepository;
+	private final ReservationConcurrencyService reservationConcurrencyService;
+	private final ReservationValidator reservationValidator;
 	private final QRCodeService qrCodeService;
 	private final PenaltyService penaltyService;
 	private final MemberDomainService memberDomainService;
@@ -244,11 +245,11 @@ public class ReservationService {
 		}
 
 		// 예약 중복 방지
-		checkDuplicateReservation(Email.of(reservationOwnerEmail));
+		reservationValidator.checkDuplicateReservation(Email.of(reservationOwnerEmail));
 
 		// 예약 가능 여부 확인
 		List<Long> idList = Arrays.stream(request.scheduleId()).toList();
-		List<Schedule> schedules = processIndividualReservationWithLock(idList);
+		List<Schedule> schedules = reservationConcurrencyService.processIndividualReservationWithLock(idList);
 		Reservation reservation = Reservation.from(schedules, true, reservationOwner);
 		reservationRepository.save(reservation);
 
@@ -256,43 +257,6 @@ public class ReservationService {
 		sendReservationSuccessEmail(schedules.get(0).getRoomType(), reservationOwnerEmail, new HashSet<>(), schedules);
 
 		return "Success";
-	}
-
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public List<Schedule> processIndividualReservationWithLock(List<Long> scheduleIds){
-		try {
-			List<Schedule> lockedSchedules = scheduleRepository.findByIdsWithPessimisticLock(scheduleIds);
-
-			if (lockedSchedules.size() != scheduleIds.size()) {
-				ReservationLogUtil.logWarn("개인 예약 실패 - 존재하지 않는 스케줄 포함됨", "스케줄 ID: " + scheduleIds);
-				throw new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄이 포함되어 있습니다.");
-			}
-
-			RoomType roomType = lockedSchedules.get(0).getRoomType();
-			if (roomType == RoomType.GROUP) {
-				ReservationLogUtil.logWarn("개인 예약 실패 - 그룹 전용 방 예약 시도",
-					"방 번호: " + lockedSchedules.get(0).getRoomNumber());
-				throw new BusinessException(StatusCode.FORBIDDEN, "해당 방은 단체예약 전용입니다.");
-			}
-
-			// 스케줄 업데이트 (currentRes 증가 및 상태 변경)
-			for (Schedule schedule : lockedSchedules) {
-				if (!schedule.isCurrentResLessThanCapacity()) {
-					ReservationLogUtil.logWarn("개인 예약 실패 - 수용 인원 초과", "스케줄 ID: " + schedule.getId());
-					throw new BusinessException(StatusCode.BAD_REQUEST, "예약 가능한 자리가 없습니다.");
-				}
-
-				schedule.reserve(); // 개인예약은 현재사용인원에서 +1 진행
-				if (schedule.getCurrentRes().equals(schedule.getCapacity())) { //예약 후 현재인원 == 방수용인원 경우 RESERVE
-					schedule.updateStatus(ScheduleSlotStatus.RESERVED);
-				}
-			}
-			scheduleRepository.saveAll(lockedSchedules);
-			return lockedSchedules;
-		} catch (PessimisticLockException e) {
-			throw new BusinessException(StatusCode.CONFLICT,
-				"현재 예약이 집중되고 있습니다. 잠시 후 다시 시도해주세요.");
-		}
 	}
 
 	@Transactional
@@ -359,7 +323,7 @@ public class ReservationService {
 
 		// 예약 가능 여부 확인
 		List<Long> idList = Arrays.stream(request.scheduleId()).toList();
-		List<Schedule> schedules = processGroupReservationWithLock(idList, uniqueEmails);
+		List<Schedule> schedules = reservationConcurrencyService.processGroupReservationWithLock(idList, uniqueEmails);
 
 		// 예약 리스트 생성
 		List<Reservation> reservations = new ArrayList<>();
@@ -377,55 +341,6 @@ public class ReservationService {
 		sendReservationSuccessEmail(schedules.get(0).getRoomType(), reservationOwnerEmail, uniqueEmails, schedules);
 
 		return "Success";
-	}
-
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public List<Schedule> processGroupReservationWithLock(List<Long> scheduleIds, Set<String> uniqueEmails){
-		try{
-			List<Schedule> lockedSchedules = scheduleRepository.findByIdsWithPessimisticLock(scheduleIds);
-
-			if (lockedSchedules.size() != scheduleIds.size()) {
-				ReservationLogUtil.logWarn("단체 예약 실패 - 존재하지 않는 스케줄 포함됨", "스케줄 ID: " + scheduleIds);
-				throw new BusinessException(StatusCode.NOT_FOUND, "존재하지 않는 스케줄이 포함되어 있습니다.");
-			}
-
-			//임계 영역에서 중복 예약 검사
-			for (String email : uniqueEmails) {
-				checkDuplicateReservation(Email.of(email));
-			}
-
-			validateSchedulesAvailable(lockedSchedules);
-
-			RoomType roomType = lockedSchedules.get(0).getRoomType();
-			if(roomType == RoomType.INDIVIDUAL) {
-				ReservationLogUtil.logWarn("단체 예약 실패 - 개인 전용 방 예약 시도", "방 번호: " + lockedSchedules.get(0).getRoomNumber());
-				throw new BusinessException(StatusCode.FORBIDDEN, "해당 방은 개인예약 전용입니다.");
-			}
-
-			// 최소 예약 인원(minRes) 검사 (예약자 + 참여자 수 체크)
-			int totalParticipants = uniqueEmails.size(); // 예약자 + 참여자 수
-			int minRes = lockedSchedules.get(0).getMinRes(); // 모든 Group 전용 schedule의 min_res는 2로 동일
-			int capacity = lockedSchedules.get(0).getCapacity(); // 같은 방의 schedule은 capacity는 동일
-			if (totalParticipants < minRes) {
-				ReservationLogUtil.logWarn("단체 예약 실패 - 최소 인원 미달", "최소 인원: " + minRes, "현재 인원: " + totalParticipants);
-				throw new BusinessException(StatusCode.BAD_REQUEST,
-					"최소 예약 인원 조건을 만족하지 않습니다. (필요 인원: " + minRes + ", 현재 인원: " + totalParticipants + ")");
-			}else if (totalParticipants > capacity) {
-				ReservationLogUtil.logWarn("단체 예약 실패 - 최대 인원 초과", "최대 수용 인원: " + capacity, "현재 인원: " + totalParticipants);
-				throw new BusinessException(StatusCode.BAD_REQUEST,
-					"방의 최대 수용 인원을 초과했습니다. (최대 수용 인원: " + capacity + ", 현재 인원: " + totalParticipants + ")");
-			}
-
-			for (Schedule schedule : lockedSchedules) {
-				schedule.updateGroupCurrentRes(totalParticipants); // 현재 사용 인원을 예약자 + 참여자 숫자로 지정
-				schedule.updateStatus(ScheduleSlotStatus.RESERVED);
-			}
-
-			return lockedSchedules;
-		}catch (PessimisticLockException e) {
-			throw new BusinessException(StatusCode.CONFLICT,
-				"현재 예약이 집중되고 있습니다. 잠시 후 다시 시도해주세요.");
-		}
 	}
 
 	@Transactional
@@ -606,35 +521,6 @@ public class ReservationService {
 		// 시간이 연속되는지 확인
 		if (!firstSchedule.getEndTime().equals(secondSchedule.getStartTime())) {
 			throw new BusinessException(StatusCode.BAD_REQUEST,"연속되지 않은 시간은 예약할 수 없습니다.");
-		}
-	}
-
-	private void validateSchedulesAvailable(List<Schedule> schedules) {
-		LocalDateTime now = LocalDateTime.now(clock);
-
-		if (schedules.stream().anyMatch(schedule -> {
-			LocalDateTime scheduleStartDateTime = LocalDateTime.of(schedule.getScheduleDate(), schedule.getStartTime());
-			return !schedule.isAvailable() ||
-				!schedule.isCurrentResLessThanCapacity() ||
-				!scheduleStartDateTime.isAfter(now); // 현재 시간보다 이전이면 예외 발생
-		})) {
-			ReservationLogUtil.logWarn("스케줄 유효성 검증 실패",
-				"현재 시간: " + now,
-				"대상 스케줄 ID 목록: " + schedules.stream().map(Schedule::getId).toList());
-			throw new BusinessException(StatusCode.BAD_REQUEST, "예약이 불가능합니다. 스케줄이 유효하지 않거나 이미 예약이 완료되었습니다.");
-		}
-	}
-
-	private void checkDuplicateReservation(Email reservationOwnerEmail) {
-		Optional<Reservation> recentReservation = reservationRepository.findLatestReservationByMemberEmail(
-			reservationOwnerEmail);
-		if (recentReservation.isPresent()) {
-			ReservationStatus recentStatus = recentReservation.get().getStatus();
-			if (recentStatus == ReservationStatus.RESERVED || recentStatus == ReservationStatus.ENTRANCE) {
-				ReservationLogUtil.logWarn("중복 예약 시도",
-					"userEmail: " + reservationOwnerEmail.getValue() + "현재 상태: " + recentStatus);
-				throw new BusinessException(StatusCode.CONFLICT, "현재 예약이 진행 중이므로 새로운 예약을 생성할 수 없습니다.");
-			}
 		}
 	}
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -251,8 +251,9 @@ public class ReservationService {
 		// 예약 가능 여부 확인
 		List<Long> idList = Arrays.stream(request.scheduleId()).toList();
 
+		List<Schedule> schedules = reservationConcurrencyService.processIndividualReservationWithLock(idList);
+
 		try {
-			List<Schedule> schedules = reservationConcurrencyService.processIndividualReservationWithLock(idList);
 			Reservation reservation = Reservation.from(schedules, true, reservationOwner);
 			reservationRepository.save(reservation);
 
@@ -335,10 +336,9 @@ public class ReservationService {
 
 		// 예약 가능 여부 확인
 		List<Long> idList = Arrays.stream(request.scheduleId()).toList();
+		List<Schedule> schedules = reservationConcurrencyService.processGroupReservationWithLock(idList, uniqueEmails);
 
 		try {
-			List<Schedule> schedules = reservationConcurrencyService.processGroupReservationWithLock(idList, uniqueEmails);
-
 			// 예약 리스트 생성
 			List<Reservation> reservations = new ArrayList<>();
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/application/ReservationService.java
@@ -268,7 +268,7 @@ public class ReservationService {
 			} catch (Exception rollbackException) {
 				ReservationLogUtil.log("예약 실패에 따른 보상 트랜잭션 실패", "예약자: " + reservationOwnerEmail + " " + rollbackException.getMessage());
 			}
-			throw e;
+			throw new BusinessException(StatusCode.INTERNAL_ERROR, "예약 처리 중 오류가 발생하여 모든 변경사항이 롤백됩니다." + e);
 		}
 	}
 
@@ -361,7 +361,7 @@ public class ReservationService {
 			} catch (Exception rollbackException) {
 				ReservationLogUtil.log("예약 실패에 따른 보상 트랜잭션 실패", "예약자: " + reservationOwnerEmail + " " + rollbackException.getMessage());
 			}
-			throw e;
+			throw new BusinessException(StatusCode.INTERNAL_ERROR, "예약 처리 중 오류가 발생하여 모든 변경사항이 롤백됩니다." + e);
 		}
 	}
 

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/service/ReservationValidator.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/domain/service/ReservationValidator.java
@@ -1,0 +1,54 @@
+package com.ice.studyroom.domain.reservation.domain.service;
+
+import com.ice.studyroom.domain.membership.domain.vo.Email;
+import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
+import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ReservationRepository;
+import com.ice.studyroom.domain.reservation.util.ReservationLogUtil;
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.StatusCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationValidator {
+
+	private final ReservationRepository reservationRepository;
+	private final Clock clock;
+
+	public void validateSchedulesAvailable(List<Schedule> schedules) {
+		LocalDateTime now = LocalDateTime.now(clock);
+
+		if (schedules.stream().anyMatch(schedule -> {
+			LocalDateTime scheduleStartDateTime = LocalDateTime.of(schedule.getScheduleDate(), schedule.getStartTime());
+			return !schedule.isAvailable() ||
+				!schedule.isCurrentResLessThanCapacity() ||
+				!scheduleStartDateTime.isAfter(now); // 현재 시간보다 이전이면 예외 발생
+		})) {
+			ReservationLogUtil.logWarn("스케줄 유효성 검증 실패",
+				"현재 시간: " + now,
+				"대상 스케줄 ID 목록: " + schedules.stream().map(Schedule::getId).toList());
+			throw new BusinessException(StatusCode.BAD_REQUEST, "예약이 불가능합니다. 스케줄이 유효하지 않거나 이미 예약이 완료되었습니다.");
+		}
+	}
+
+	public void checkDuplicateReservation(Email reservationOwnerEmail) {
+		Optional<Reservation> recentReservation = reservationRepository.findLatestReservationByMemberEmail(
+			reservationOwnerEmail);
+		if (recentReservation.isPresent()) {
+			ReservationStatus recentStatus = recentReservation.get().getStatus();
+			if (recentStatus == ReservationStatus.RESERVED || recentStatus == ReservationStatus.ENTRANCE) {
+				ReservationLogUtil.logWarn("중복 예약 시도",
+					"userEmail: " + reservationOwnerEmail.getValue() + "현재 상태: " + recentStatus);
+				throw new BusinessException(StatusCode.CONFLICT, "현재 예약이 진행 중이므로 새로운 예약을 생성할 수 없습니다.");
+			}
+		}
+	}
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,6 +9,12 @@ spring.redis.host=${REDIS_URL}
 spring.redis.port=${REDIS_PORT}
 spring.redis.password=${REDIS_PASSWORD}
 
+# hikaricp setting
+spring.datasource.hikari.maximum-pool-size=${DB_MAX_POOL_SIZE:30}
+spring.datasource.hikari.minimum-idle=${DB_MIN_IDLE:10}
+spring.datasource.hikari.idle-timeout=${DB_IDLE_TIMEOUT:600000}
+spring.datasource.hikari.connection-timeout=${DB_CONN_TIMEOUT:3000}
+
 # JPA Basic Configuration
 spring.jpa.hibernate.ddl-auto=${PROD_JPA_DDL_AUTO}
 spring.jpa.show-sql=${PROD_JPA_SHOW_SQL}

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/QrEntranceTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/QrEntranceTest.java
@@ -10,6 +10,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Optional;
 
+import com.ice.studyroom.domain.reservation.domain.service.ReservationValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +46,8 @@ class QrEntranceTest {
 	@Mock private MemberRepository memberRepository;
 	@Mock private ReservationRepository reservationRepository;
 	@Mock private ScheduleRepository scheduleRepository;
+	@Mock private ReservationConcurrencyService reservationConcurrencyService;
+	@Mock private ReservationValidator reservationValidator;
 	@Mock private QRCodeService qrCodeService;
 	@Mock private PenaltyService penaltyService;
 	@Mock private MemberDomainService memberDomainService;
@@ -66,7 +69,7 @@ class QrEntranceTest {
 		);
 		reservationService = new ReservationService(
 			qrCodeUtil, tokenService, memberRepository, reservationRepository,
-			scheduleRepository, qrCodeService, penaltyService,
+			scheduleRepository, reservationConcurrencyService, reservationValidator, qrCodeService, penaltyService,
 			memberDomainService, emailService, clock
 		);
 	}
@@ -316,7 +319,7 @@ class QrEntranceTest {
 		this.clock = Clock.fixed(dateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
 		reservationService = new ReservationService(
 			qrCodeUtil, tokenService, memberRepository, reservationRepository,
-			scheduleRepository, qrCodeService, penaltyService,
+			scheduleRepository, reservationConcurrencyService, reservationValidator, qrCodeService, penaltyService,
 			memberDomainService, emailService, clock
 		);
 	}

--- a/backend/src/test/java/com/ice/studyroom/domain/reservation/application/QrEntranceTest.java
+++ b/backend/src/test/java/com/ice/studyroom/domain/reservation/application/QrEntranceTest.java
@@ -47,6 +47,7 @@ class QrEntranceTest {
 	@Mock private ReservationRepository reservationRepository;
 	@Mock private ScheduleRepository scheduleRepository;
 	@Mock private ReservationConcurrencyService reservationConcurrencyService;
+	@Mock private ReservationCompensationService reservationCompensationService;
 	@Mock private ReservationValidator reservationValidator;
 	@Mock private QRCodeService qrCodeService;
 	@Mock private PenaltyService penaltyService;
@@ -69,7 +70,7 @@ class QrEntranceTest {
 		);
 		reservationService = new ReservationService(
 			qrCodeUtil, tokenService, memberRepository, reservationRepository,
-			scheduleRepository, reservationConcurrencyService, reservationValidator, qrCodeService, penaltyService,
+			scheduleRepository, reservationConcurrencyService, reservationCompensationService, reservationValidator, qrCodeService, penaltyService,
 			memberDomainService, emailService, clock
 		);
 	}
@@ -319,7 +320,7 @@ class QrEntranceTest {
 		this.clock = Clock.fixed(dateTime.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
 		reservationService = new ReservationService(
 			qrCodeUtil, tokenService, memberRepository, reservationRepository,
-			scheduleRepository, reservationConcurrencyService, reservationValidator, qrCodeService, penaltyService,
+			scheduleRepository, reservationConcurrencyService, reservationCompensationService, reservationValidator, qrCodeService, penaltyService,
 			memberDomainService, emailService, clock
 		);
 	}


### PR DESCRIPTION
## PR 종류
- [x] 리팩토링

## 변경 사항
- 트랜잭션을 분리하여 락 조회 시 정상적으로 새로운 트랜잭션이 적용되게 구현
- 항상 정렬된 Schedule을 접근하여 데드락이 발생하지않게 변경
- 외부 트랜잭션 실패 시 수행하는 보상 트랜잭션 구현 및 추가

## 관련 이슈
- #500 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
### 내부 호출로 인한 트랜잭션 분리 실패
<img width="1176" height="651" alt="image" src="https://github.com/user-attachments/assets/35140e50-7f8e-4ed9-8292-6b3ff8133831" />

```bash
2025-07-11 18:04:43.629 [http-nio-0.0.0.0-8080-exec-1] INFO  c.i.s.d.m.d.util.MembershipLogUtil - [MEMBERSHIP] 로그인 요청 - [email: glaxyt@hufs.ac.kr] [requestId=24d84364-66ce-4410-8a60-878f27e7771b, userEmail=]
2025-07-11 18:04:44.134 [http-nio-0.0.0.0-8080-exec-1] INFO  c.i.s.d.m.d.util.MembershipLogUtil - [MEMBERSHIP] 로그인 성공 - [email: glaxyt@hufs.ac.kr] [requestId=24d84364-66ce-4410-8a60-878f27e7771b, userEmail=]
2025-07-11 18:05:06.646 [http-nio-0.0.0.0-8080-exec-3] INFO  c.i.s.d.r.a.ReservationService - [createIndividualReservation] txActive = true, txName = com.ice.studyroom.domain.reservation.application.ReservationService.createIndividualReservation [requestId=b14ccfd4-467a-4907-a318-8e526e50f066, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:05:06.648 [http-nio-0.0.0.0-8080-exec-3] INFO  c.i.s.d.r.util.ReservationLogUtil - [RESERVATION] 개인 예약 생성 요청 - [스케줄 ID: [3824, 3823], 참여자 이메일: []] [requestId=b14ccfd4-467a-4907-a318-8e526e50f066, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:05:06.663 [http-nio-0.0.0.0-8080-exec-3] INFO  c.i.s.d.r.a.ReservationService - [processIndividualReservationWithLock] txActive = true, txName = com.ice.studyroom.domain.reservation.application.ReservationService.createIndividualReservation [requestId=b14ccfd4-467a-4907-a318-8e526e50f066, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:05:06.664 [http-nio-0.0.0.0-8080-exec-3] WARN  org.hibernate.orm.deprecation - HHH90000021: Encountered deprecated setting [javax.persistence.lock.timeout], use [jakarta.persistence.lock.timeout] instead [requestId=b14ccfd4-467a-4907-a318-8e526e50f066, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:05:06.718 [http-nio-0.0.0.0-8080-exec-3] INFO  c.i.s.d.r.util.ReservationLogUtil - [RESERVATION] 개인 예약 생성 성공 - [예약자: glaxyt@hufs.ac.kr, 예약 ID: 111] [requestId=b14ccfd4-467a-4907-a318-8e526e50f066, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:05:11.361 [EmailExecutor-1] INFO  c.i.s.global.service.GmailService - 이메일 전송 성공 - 수신자: glaxyt@hufs.ac.kr, 제목: [ICE-STUDYRES] 스터디룸 예약이 완료되었습니다. [requestId=, userEmail=]
```
```java
	private void logCurrentTx(String methodName) {
		boolean active = TransactionSynchronizationManager.isActualTransactionActive();
		String txName = TransactionSynchronizationManager.getCurrentTransactionName();
		log.info("[{}] txActive = {}, txName = {}", methodName, active, txName);
	}
```
- 위의 트랜잭션 로깅으로 직접 사용자의 API의 호출로 테스트 해보았음
- 위 로그에서 트랜잭션 이름이 동일한 것을 확인할 수 있음.(com.ice.studyroom.domain.reservation.application.ReservationService.createIndividualReservation)
- 따라서 REQUIRED_NEW를 적용하더라도 동일한 트랜잭션이 적용되고 있음
  
### 락 서비스를 새로운 클래스로 분리
- ReservationConcurrencyService.java 구현
- 기존에는 `@Transactional(propagation = REQUIRES_NEW)`가 선언된 `processIndividualReservationWithLock()` 메서드를 동일 클래스 내에서 직접 호출하여 **프록시를 거치지 않아** 트랜잭션 분리가 적용되지 않았음
- 이를 해결하기 위해 **트랜잭션 분리 전용 클래스(`ReservationConcurrencyService`)를 생성**하고, 애플리케이션 서비스에서 해당 클래스를 호출하도록 구조를 변경
- 이를 통해 추후 **스케줄 락 처리 로직은 별도의 트랜잭션에서 안전하게 실행**되며, 메인 트랜잭션과 독립적으로 롤백될 수 있음
  
### 데드락 방지를 위한 Schedule ID 정렬 적용
```java
@Service
@Slf4j
@RequiredArgsConstructor
public class ReservationConcurrencyService {

	private final ScheduleRepository scheduleRepository;
	private final ReservationValidator reservationValidator;

	@Transactional(propagation = Propagation.REQUIRES_NEW)
	public List<Schedule> processIndividualReservationWithLock(List<Long> scheduleIds){
		try {
                         // 정렬된 레코드 순서로 접근할 수 있게 변경
			List<Long> sortedScheduleIds = new ArrayList<>(scheduleIds);
			Collections.sort(sortedScheduleIds);

                        //.. 코드 생략
                }
        }

        // .. 그룹 예약 로직에서도 정렬된 레코드로 접근할 수 있게 변경
}
```
- 스케줄 조회 시, **ID를 정렬하지 않고 비관적 락을 획득할 경우 데드락 위험이 존재**
- 이를 방지하기 위해 **예약 대상 스케줄 ID를 정렬한 뒤 조회**하도록 수정 (`Collections.sort()` 적용)
- 정렬 기준은 `ID 오름차순`이며, 트랜잭션 경합 상황에서도 일관된 락 획득 순서를 보장

### 직접 테스트
<img width="1171" height="653" alt="image" src="https://github.com/user-attachments/assets/f79197da-4bd2-469b-bec4-064d5c105f3b" />  

```bash
2025-07-11 18:15:35.776 [http-nio-0.0.0.0-8080-exec-5] INFO  c.i.s.d.r.a.ReservationService - [createIndividualReservation] txActive = true, txName = com.ice.studyroom.domain.reservation.application.ReservationService.createIndividualReservation [requestId=2e135933-2ab4-468a-b8dc-379ec519b417, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:15:35.780 [http-nio-0.0.0.0-8080-exec-5] INFO  c.i.s.d.r.util.ReservationLogUtil - [RESERVATION] 개인 예약 생성 요청 - [스케줄 ID: [3811, 3810], 참여자 이메일: []] [requestId=2e135933-2ab4-468a-b8dc-379ec519b417, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:15:35.788 [http-nio-0.0.0.0-8080-exec-5] INFO  c.i.s.d.r.a.ReservationConcurrencyService - [processIndividualReservationWithLock] txActive = true, txName = com.ice.studyroom.domain.reservation.application.ReservationConcurrencyService.processIndividualReservationWithLock [requestId=2e135933-2ab4-468a-b8dc-379ec519b417, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:15:35.788 [http-nio-0.0.0.0-8080-exec-5] WARN  org.hibernate.orm.deprecation - HHH90000021: Encountered deprecated setting [javax.persistence.lock.timeout], use [jakarta.persistence.lock.timeout] instead [requestId=2e135933-2ab4-468a-b8dc-379ec519b417, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:15:35.883 [http-nio-0.0.0.0-8080-exec-5] INFO  c.i.s.d.r.util.ReservationLogUtil - [RESERVATION] 개인 예약 생성 성공 - [예약자: glaxyt@hufs.ac.kr, 예약 ID: 112] [requestId=2e135933-2ab4-468a-b8dc-379ec519b417, userEmail=glaxyt@hufs.ac.kr]
2025-07-11 18:15:40.591 [EmailExecutor-1] INFO  c.i.s.global.service.GmailService - 이메일 전송 성공 - 수신자: glaxyt@hufs.ac.kr, 제목: [ICE-STUDYRES] 스터디룸 예약이 완료되었습니다. [requestId=, userEmail=]
```  
- 정상적으로 두 메서드가 다른 트랜잭션으로 분리됨을 알 수 있음(com.ice.studyroom.domain.reservation.application.ReservationService.createIndividualReservation, com.ice.studyroom.domain.reservation.application.ReservationConcurrencyService.processIndividualReservationWithLock)

### 보상 트랜잭션 구현 및 추가
```java
@Service
@Slf4j
@RequiredArgsConstructor
public class ReservationCompensationService {

	private final ScheduleRepository scheduleRepository;

	@Transactional(propagation = Propagation.REQUIRES_NEW)
	public void rollbackSchedules(List<Long> scheduleIds, String email) {
		List<Long> sortedScheduleIds = new ArrayList<>(scheduleIds);
		Collections.sort(sortedScheduleIds);

		List<Schedule> schedules = scheduleRepository.findByIdsWithPessimisticLock(sortedScheduleIds);

		for (Schedule schedule : schedules) {
			// 개인 예약을 위해 +1 했던 currentRes를 되돌림
			schedule.cancel();
		}

		scheduleRepository.saveAll(schedules);
		ReservationLogUtil.log("보상 트랜잭션 수행 완료", "예약자: " + email, "롤백된 스케줄 ID: " + scheduleIds);
	}
}
```
- 내부 트랜잭션 성공 후 외부 트랜잭션에서 실패할 경우 보상 트랜잭션이 필요

```java
@Slf4j
@Service
@RequiredArgsConstructor
public class ReservationService {
     
        // .. 다른 메서드 및 빈 주입 코드

        @Transactional
	public String createIndividualReservation(String authorizationHeader, CreateReservationRequest request) {

                // .. 개인 예약 비즈니스 로직 생략
		List<Schedule> schedules = reservationConcurrencyService.processIndividualReservationWithLock(idList);

		try {
			Reservation reservation = Reservation.from(schedules, true, reservationOwner);
			reservationRepository.save(reservation);

                        // 세부 로직

		} catch (Exception e) {
			try {
				reservationCompensationService.rollbackSchedules(idList, reservationOwnerEmail);
			} catch (Exception rollbackException) {
				ReservationLogUtil.log("예약 실패에 따른 보상 트랜잭션 실패", "예약자: " + reservationOwnerEmail + " " + rollbackException.getMessage());
			}
			throw new BusinessException(StatusCode.INTERNAL_ERROR, "예약 처리 중 오류가 발생하여 모든 변경사항이 롤백됩니다." + e);
		}
	}
}
```
- 보상트랜잭션이 실패하는 것까지 고려해서 코드 작성

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
