### PR TITLE
[BE-#507] 빈자리 알림 등록 API 구현

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/membership/domain/exception/member/MemberNotFoundException.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/membership/domain/exception/member/MemberNotFoundException.java
@@ -1,0 +1,18 @@
+package com.ice.studyroom.domain.membership.domain.exception.member;
+
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.ActionType;
+import com.ice.studyroom.global.type.StatusCode;
+import lombok.Getter;
+
+@Getter
+public class MemberNotFoundException extends BusinessException {
+	private final String requesterEmail;
+	private final String description;
+
+	public MemberNotFoundException(String requesterEmail, ActionType actionType) {
+		super(StatusCode.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+		this.requesterEmail = requesterEmail;
+		this.description = actionType.getDescription();
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/ReservationController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/reservation/presentation/ReservationController.java
@@ -3,7 +3,6 @@ package com.ice.studyroom.domain.reservation.presentation;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ice.studyroom.domain.reservation.application.ReservationService;
-import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
 import com.ice.studyroom.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import com.ice.studyroom.domain.reservation.presentation.dto.response.CancelReservationResponse;
 import com.ice.studyroom.domain.reservation.presentation.dto.response.GetMostRecentReservationResponse;
@@ -83,16 +81,6 @@ public class ReservationController {
 		return ResponseEntity
 			.status(StatusCode.OK.getStatus())
 			.body(ResponseDto.of(reservationService.getMyReservationQrCode(resId, authorizationHeader)));
-	}
-
-	@Operation(summary = "스터디룸 일정 조회", description = "스터디룸 예약 가능한 일정을 조회합니다.")
-	@ApiResponse(responseCode = "200", description = "스터디룸 일정 조회 성공")
-	@ApiResponse(responseCode = "500", description = "스터디룸 일정 조회 실패")
-	@GetMapping("/schedules")
-	public ResponseEntity<ResponseDto<List<Schedule>>> getSchedule() {
-		return ResponseEntity
-			.status(HttpStatus.OK)
-			.body(ResponseDto.of(reservationService.getSchedule()));
 	}
 
 	@Operation(summary = "단체 스터디룸 예약", description = "단체 단위로 스터디룸을 예약합니다.")

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/application/ScheduleService.java
@@ -12,12 +12,10 @@ import com.ice.studyroom.global.security.service.TokenService;
 
 import com.ice.studyroom.global.type.ActionType;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 public class ScheduleService {
 

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/application/ScheduleService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/application/ScheduleService.java
@@ -1,0 +1,42 @@
+package com.ice.studyroom.domain.schedule.application;
+
+import com.ice.studyroom.domain.membership.domain.entity.Member;
+import com.ice.studyroom.domain.membership.domain.exception.member.MemberNotFoundException;
+import com.ice.studyroom.domain.membership.domain.vo.Email;
+import com.ice.studyroom.domain.membership.infrastructure.persistence.MemberRepository;
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
+import com.ice.studyroom.domain.reservation.infrastructure.persistence.ScheduleRepository;
+import com.ice.studyroom.domain.schedule.domain.exception.schedule.ScheduleNotFoundException;
+import com.ice.studyroom.domain.schedule.infrastructure.redis.ScheduleVacancyAlertService;
+import com.ice.studyroom.global.security.service.TokenService;
+
+import com.ice.studyroom.global.type.ActionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduleService {
+
+	private final TokenService tokenService;
+	private final MemberRepository memberRepository;
+	private final ScheduleRepository scheduleRepository;
+	private final ScheduleVacancyAlertService scheduleVacancyAlertService;
+
+	@Transactional(readOnly = true)
+	public String registerVacancyAlert(Long scheduleId, String authorizationHeader) {
+		String requesterEmail = tokenService.extractEmailFromAccessToken(authorizationHeader);
+
+		Member member = memberRepository.findByEmail(Email.of(requesterEmail))
+			.orElseThrow(() -> new MemberNotFoundException(requesterEmail, ActionType.VACANCY_ALERT));
+		Schedule schedule = scheduleRepository.findById(scheduleId)
+				.orElseThrow(() ->  new ScheduleNotFoundException(scheduleId, requesterEmail, ActionType.VACANCY_ALERT));
+
+		scheduleVacancyAlertService.registerVacancyAlert(scheduleId, requesterEmail, member.getName());
+
+		return "빈자리 알림이 등록되었습니다.";
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/domain/exception/schedule/ScheduleNotFoundException.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/domain/exception/schedule/ScheduleNotFoundException.java
@@ -1,0 +1,20 @@
+package com.ice.studyroom.domain.schedule.domain.exception.schedule;
+
+import com.ice.studyroom.global.exception.BusinessException;
+import com.ice.studyroom.global.type.ActionType;
+import com.ice.studyroom.global.type.StatusCode;
+import lombok.Getter;
+
+@Getter
+public class ScheduleNotFoundException extends BusinessException {
+	private final Long scheduleId;
+	private final String requesterEmail;
+	private final String description;
+
+	public ScheduleNotFoundException(Long scheduleId, String requesterEmail, ActionType actionType) {
+		super(StatusCode.NOT_FOUND, "유효하지않은 스케줄입니다.");
+		this.scheduleId = scheduleId;
+		this.requesterEmail = requesterEmail;
+		this.description = actionType.getDescription();
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
@@ -30,9 +30,9 @@ public class ScheduleVacancyAlertService {
 
 		if (redisTemplate.getExpire(redisKey) < 0) {
 			redisTemplate.expire(redisKey, Duration.ofHours(24));
-			ReservationLogUtil.log("새로운 빈자리 알림 키 생성. Key: {}, Expire: 24 hours", redisKey);
+			ReservationLogUtil.log("새로운 빈자리 알림 키 생성. Key: " + redisKey + ", Expire: 24 hours");
 		}
 
-		ReservationLogUtil.log("빈자리 알림 등록 완료. Key: {}, Email: {}, User: {}", redisKey, email, userName);
+		ReservationLogUtil.log("빈자리 알림 등록 완료. Key: " + redisKey + ", Email: " + email + ", User: " + userName);
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
@@ -1,0 +1,38 @@
+package com.ice.studyroom.domain.schedule.infrastructure.redis;
+
+import com.ice.studyroom.domain.reservation.util.ReservationLogUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduleVacancyAlertService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private static final String REDIS_KEY_PREFIX = "vacancy-notification:";
+
+	/**
+	 * 특정 스터디룸에 대한 빈자리 알림을 신청합니다.
+	 * @param scheduleId 알림을 받을 스케줄 ID
+	 * @param email 알림을 받을 사용자의 이메일
+	 * @param userName 알림을 받을 사용자의 이름
+	 */
+	public void registerVacancyAlert(Long scheduleId, String email, String userName) {
+		String redisKey = REDIS_KEY_PREFIX + scheduleId;
+
+		redisTemplate.opsForHash().put(redisKey, email, userName);
+
+		if (redisTemplate.getExpire(redisKey) < 0) {
+			redisTemplate.expire(redisKey, Duration.ofHours(24));
+			ReservationLogUtil.log("새로운 빈자리 알림 키 생성. Key: {}, Expire: 24 hours", redisKey);
+		}
+
+		ReservationLogUtil.log("빈자리 알림 등록 완료. Key: {}, Email: {}, User: {}", redisKey, email, userName);
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
@@ -15,7 +15,7 @@ public class ScheduleVacancyAlertService {
 
 	private final RedisTemplate<String, Object> redisTemplate;
 
-	private static final String REDIS_KEY_PREFIX = "vacancy-notification:";
+	private static final String REDIS_KEY_PREFIX = "vacancy-notification:schedule:";
 
 	/**
 	 * 특정 스터디룸에 대한 빈자리 알림을 신청합니다.

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/infrastructure/redis/ScheduleVacancyAlertService.java
@@ -2,14 +2,12 @@ package com.ice.studyroom.domain.schedule.infrastructure.redis;
 
 import com.ice.studyroom.domain.reservation.util.ReservationLogUtil;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 public class ScheduleVacancyAlertService {
 

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/presentation/ScheduleController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/presentation/ScheduleController.java
@@ -1,0 +1,31 @@
+package com.ice.studyroom.domain.schedule.presentation;
+
+import com.ice.studyroom.domain.schedule.application.ScheduleService;
+import com.ice.studyroom.global.dto.response.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/schedules")
+@Tag(
+	name = "Study Room",
+	description = "스터디룸 스케줄 조회, 빈자리 알림 기능을 제공합니다."
+)
+@RequiredArgsConstructor
+public class ScheduleController {
+
+	private final ScheduleService scheduleService;
+
+	@Operation(summary = "특정 스케줄 빈자리 알림 신청", description = "이미 예약된 특정 스케줄에 빈자리가 생길 경우 알림을 받도록 등록합니다.")
+	@PostMapping("/{scheduleId}/vacancy-alert")
+	public ResponseEntity<ResponseDto<String>> registerVacancyAlert(
+		@PathVariable long scheduleId,
+		@RequestHeader("Authorization") String authorizationHeader
+	) {
+		return ResponseEntity.ok(ResponseDto.of(scheduleService.registerVacancyAlert(scheduleId, authorizationHeader)));
+	}
+}

--- a/backend/src/main/java/com/ice/studyroom/domain/schedule/presentation/ScheduleController.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/schedule/presentation/ScheduleController.java
@@ -1,13 +1,18 @@
 package com.ice.studyroom.domain.schedule.presentation;
 
+import com.ice.studyroom.domain.reservation.application.ReservationService;
+import com.ice.studyroom.domain.reservation.domain.entity.Schedule;
 import com.ice.studyroom.domain.schedule.application.ScheduleService;
 import com.ice.studyroom.global.dto.response.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/schedules")
@@ -19,6 +24,17 @@ import org.springframework.web.bind.annotation.*;
 public class ScheduleController {
 
 	private final ScheduleService scheduleService;
+	private final ReservationService reservationService;
+
+	@Operation(summary = "스터디룸 일정 조회", description = "스터디룸 예약 가능한 일정을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "스터디룸 일정 조회 성공")
+	@ApiResponse(responseCode = "500", description = "스터디룸 일정 조회 실패")
+	@GetMapping()
+	public ResponseEntity<ResponseDto<List<Schedule>>> getSchedule() {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ResponseDto.of(reservationService.getSchedule()));
+	}
 
 	@Operation(summary = "특정 스케줄 빈자리 알림 신청", description = "이미 예약된 특정 스케줄에 빈자리가 생길 경우 알림을 받도록 등록합니다.")
 	@PostMapping("/{scheduleId}/vacancy-alert")

--- a/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ice/studyroom/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ice.studyroom.global.exception;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.ice.studyroom.domain.membership.domain.exception.member.MemberNotFoundException;
 import com.ice.studyroom.domain.reservation.domain.exception.reservation.ReservationNotFoundException;
 import com.ice.studyroom.domain.reservation.domain.exception.reservation.cancel.InvalidCancelAttemptException;
 import com.ice.studyroom.domain.reservation.domain.exception.reservation.qr.InvalidEntranceAttemptException;
@@ -11,6 +12,7 @@ import com.ice.studyroom.domain.reservation.domain.exception.reservation.qr.QrIs
 import com.ice.studyroom.domain.reservation.domain.exception.reservation.ReservationAccessDeniedException;
 import com.ice.studyroom.domain.reservation.domain.exception.reservation.ReservationScheduleNotFoundException;
 import com.ice.studyroom.domain.reservation.util.ReservationLogUtil;
+import com.ice.studyroom.domain.schedule.domain.exception.schedule.ScheduleNotFoundException;
 import com.ice.studyroom.global.exception.token.InvalidQrTokenException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -96,6 +98,22 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(ReservationNotFoundException.class)
 	public ResponseEntity<ResponseDto<Object>> handleReservationNotFound(ReservationNotFoundException ex) {
 		ReservationLogUtil.logWarn("["+ ex.getDescription() +"]" + "찾을 수 없는 예약", "예약 ID: " + ex.getReservationId() + " 접근 시도자: " + ex.getRequesterEmail());
+		return ResponseEntity
+			.status(ex.getStatusCode().getStatus())
+			.body(ResponseDto.error(ex.getStatusCode(), ex.getMessage()));
+	}
+
+	@ExceptionHandler(ScheduleNotFoundException.class)
+	public ResponseEntity<ResponseDto<Object>> handleScheduleNotFound(ScheduleNotFoundException ex) {
+		ReservationLogUtil.logWarn("["+ ex.getDescription() +"]" + "찾을 수 없는 스케줄", "스케줄 ID: " + ex.getScheduleId() + " 접근 시도자: " + ex.getRequesterEmail());
+		return ResponseEntity
+			.status(ex.getStatusCode().getStatus())
+			.body(ResponseDto.error(ex.getStatusCode(), ex.getMessage()));
+	}
+
+	@ExceptionHandler(MemberNotFoundException.class)
+	public ResponseEntity<ResponseDto<Object>> handleMemberNotFound(MemberNotFoundException ex) {
+		ReservationLogUtil.logWarn("["+ ex.getDescription() +"]" + "찾을 수 없는 사용자", " 접근 시도자: " + ex.getRequesterEmail());
 		return ResponseEntity
 			.status(ex.getStatusCode().getStatus())
 			.body(ResponseDto.error(ex.getStatusCode(), ex.getMessage()));

--- a/backend/src/main/java/com/ice/studyroom/global/type/ActionType.java
+++ b/backend/src/main/java/com/ice/studyroom/global/type/ActionType.java
@@ -1,5 +1,8 @@
 package com.ice.studyroom.global.type;
 
+import lombok.Getter;
+
+@Getter
 public enum ActionType {
 	VACANCY_ALERT("빈자리 알림 등록");
 
@@ -7,9 +10,5 @@ public enum ActionType {
 
 	ActionType(String description) {
 		this.description = description;
-	}
-
-	public String getDescription() {
-		return description;
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/global/type/ActionType.java
+++ b/backend/src/main/java/com/ice/studyroom/global/type/ActionType.java
@@ -1,0 +1,15 @@
+package com.ice.studyroom.global.type;
+
+public enum ActionType {
+	VACANCY_ALERT("빈자리 알림 등록");
+
+	private final String description;
+
+	ActionType(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+}


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능

## 변경 사항

- 빈자리 알림 등록 서비스를 구현합니다.
  - 사용자가 알림 등록을 할 수 있게 API를 호출할 수 있게합니다.
  - 사용자의 정보는 Redis에 저장됩니다.
- 저장 구조는 예시는 아래와 같습니다.
  - "vacancy-notification:schedule:11": { "glaxyt@hufs.ac.kr" : "도성현", "example@hufs.ac.kr": "심재성" }
  - "vacancy-notification:schedule:11"의 11은 scheduleId를 뜻합니다.
  - 이 정보는 추후에 빈자리가 발생하면 카프카를 통해서 전달됩니다.

## 관련 이슈
- #507 

## 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
### 빈자리 알림 등록 API 호출
<img width="851" height="687" alt="image" src="https://github.com/user-attachments/assets/1e77f24d-c949-453c-8b6c-c3d7168edc2b" />
  
- POST "/api/schedules/{scheduleId}/vacancy-alert" + AccessToken
- Body는 없습니다. 오직 쿼리 파라미터와 AccessToken만으로 수행이 가능합니다.

### 빈자리 등록 알림을 받을 명단을 관리하는 캐시 서비스
```java
@Service
@RequiredArgsConstructor
public class ScheduleVacancyAlertService {

	private final RedisTemplate<String, Object> redisTemplate;

	private static final String REDIS_KEY_PREFIX = "vacancy-notification:schedule:";

	/**
	 * 특정 스터디룸에 대한 빈자리 알림을 신청합니다.
	 * @param scheduleId 알림을 받을 스케줄 ID
	 * @param email 알림을 받을 사용자의 이메일
	 * @param userName 알림을 받을 사용자의 이름
	 */
	public void registerVacancyAlert(Long scheduleId, String email, String userName) {
		String redisKey = REDIS_KEY_PREFIX + scheduleId;

		redisTemplate.opsForHash().put(redisKey, email, userName);

		if (redisTemplate.getExpire(redisKey) < 0) {
			redisTemplate.expire(redisKey, Duration.ofHours(24));
			ReservationLogUtil.log("새로운 빈자리 알림 키 생성. Key: " + redisKey + ", Expire: 24 hours");
		}

		ReservationLogUtil.log("빈자리 알림 등록 완료. Key: " + redisKey + ", Email: " + email + ", User: " + userName);
	}
}
```
- Redis에 저장되는 데이터를 관리합니다.
- TTL을 최초 저장 시점을 기준으로 24시간 동안 유지됩니다.
- "vacancy-notification:schedule:11": { "glaxyt@hufs.ac.kr" : "도성현", "example@hufs.ac.kr": "심재성" }
  - "vacancy-notification:schedule:11"의 11은 scheduleId를 뜻합니다.

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
