### PR TITLE
[BE-#518] 카프카 장애 발생을 대비한 Resilience4j 서킷 브레이커 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -72,6 +72,8 @@ management.metrics.tags.namespace=prod
 management.metrics.enable.jvm=true
 management.metrics.enable.tomcat=true
 
+spring.config.import=classpath:resilience4j.yml
+
 # Kafka Settings
 spring.kafka.bootstrap-servers=${KAFKA_URL:localhost:9092}
 spring.kafka.producer.properties.enable.idempotence=true

--- a/backend/src/main/resources/resilience4j.yml
+++ b/backend/src/main/resources/resilience4j.yml
@@ -1,0 +1,15 @@
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        registerHealthIndicator: true
+        slidingWindowSize: 10
+        failureRateThreshold: 50
+        waitDurationInOpenState: 20s
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        slowCallRateThreshold: 60
+        slowCallDurationThreshold: 2s
+    instances:
+      kafka-producer:
+        base-config: default


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능

## 변경 사항
###  Resilience4j 서킷 브레이커 적용
```java
@Service
@RequiredArgsConstructor
public class VacancyNotificationProducer {

        // 코드 생략

	@CircuitBreaker(name = KAFKA_PRODUCER_CIRCUIT, fallbackMethod = "handleSendFailure")
	public CompletableFuture<Void> sendSingleNotification(VacancyNotificationRequest request) {
		return kafkaTemplate.send(TOPIC_NAME, request)
			.whenComplete((result, ex) -> {
				if (ex == null) {
					log.info("빈자리 알림 이메일 전송 성공. 이메일: {} 토픽: {}",
						request.getEmail(),
						result.getRecordMetadata().topic());
				}
			})
			.thenAccept(sendResult -> {});
	}

	private CompletableFuture<Void> handleSendFailure(VacancyNotificationRequest request, Throwable throwable) {
		if (throwable instanceof CallNotPermittedException) {
			log.error("서킷 브레이커가 OPEN 상태입니다. 카프카 전송을 시도하지 않습니다. Email: {}", request.getEmail());
		} else {
			log.error("빈자리 알림 이메일 전송 실패. 이메일: {} 에러: {}", request.getEmail(), throwable.getMessage());
		}
		return CompletableFuture.completedFuture(null);
	}
}
```
- 카프카 장애 발생 시 Resilience4j에 설정된 내용에 따라 서킷 브레이커 실행

### 카프카 서킷 브레이커 설정
기본설정
- slidingWindowSize: 10 - 최근 10개 호출을 기준으로 실패율 계산
- failureRateThreshold: 50 - 실패율 50% 초과 시 Circuit Breaker 열림
- waitDurationInOpenState: 20s - Open 상태에서 20초 대기 후 Half-Open으로 전환
Half-Open 상태 설정
- permittedNumberOfCallsInHalfOpenState: 3 - Half-Open에서 3개 호출만 허용
- automaticTransitionFromOpenToHalfOpenEnabled: true - 자동으로 Half-Open 전환 활성화
Slow Call 감지
- slowCallRateThreshold: 60 - 느린 호출 비율 60% 초과 시 Circuit Breaker 동작
- slowCallDurationThreshold: 2s - 2초 이상 소요되면 느린 호출로 판단


## 관련 이슈
- #518 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- 필요한 경우 스크린샷을 첨부해주세요.

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
