### PR TITLE
[BE-#539] openjdk:17-slim deprecated 해결

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,11 @@
 # 1. 사용할 기본 이미지 (OpenJDK 17 JRE)
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jre-alpine
 
 # 2. 타임존 설정 추가
 ENV TZ=Asia/Seoul
-RUN ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apk add --no-cache tzdata && \
+    ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
 
 # 3. 작업 디렉토리 설정
 WORKDIR /app


### PR DESCRIPTION
## PR 종류
- [x] 버그 수정

## 변경 사항

- openjdk:17-slim deprecated 되었기에 Eclipse Temurin으로 변경

## 관련 이슈
- #539 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- 필요한 경우 스크린샷을 첨부해주세요.

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
