### PR TITLE
[BE-#547] DJL(PyTorch) 로딩 오류 관련 Dockerfile 수정 (glibc 기반 이미지 적용)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,20 +1,18 @@
-# 1. 사용할 기본 이미지 (OpenJDK 17 JRE)
+# 1. 사용할 기본 이미지 (OpenJDK 17 JRE, glibc 기반)
 FROM eclipse-temurin:17-jre
 
-# 2. 필수 라이브러리 추가 (C++ 표준 라이브러리)
-RUN apk add --no-cache libstdc++
+# 2. 필수 라이브러리 추가 (libstdc++, tzdata)
+RUN apt-get update && \
+    apt-get install -y libstdc++6 tzdata && \
+    ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo "Asia/Seoul" > /etc/timezone && \
+    rm -rf /var/lib/apt/lists/*
 
-# 3. 타임존 설정 추가
-ENV TZ=Asia/Seoul
-RUN apk add --no-cache tzdata && \
-    ln -sf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    echo $TZ > /etc/timezone
-
-# 4. 작업 디렉토리 설정
+# 3. 작업 디렉토리 설정
 WORKDIR /app
 RUN mkdir -p logs
 
-# 5. CI/CD에서 빌드된 JAR 파일을 컨테이너 내부로 복사
+# 4. CI/CD에서 빌드된 JAR 파일을 컨테이너 내부로 복사
 COPY build/libs/*.jar app.jar
 
 # 5. 컨테이너 실행 명령어 지정


### PR DESCRIPTION
## PR 종류
- [x] 기능 개선

---

## 변경 사항
- Alpine(musl) 기반 `eclipse-temurin:17-jre-alpine` 이미지에서 glibc가 없어 DJL(PyTorch) 네이티브 라이브러리 로딩 실패 발생  
- Dockerfile을 glibc 기반 이미지(`eclipse-temurin:17-jre`)로 교체하여 DJL(PyTorch) 엔진이 필요한 `ld-linux-x86-64.so.2` 로더를 포함하도록 수정  
- `libstdc++6`, `tzdata` 설치 추가로 런타임 의존성 보완  
- `LocalEmbeddingService` 초기화 시 `EngineException`(`Failed to load PyTorch native library`) 발생 문제 해결  

---

## 관련 이슈
Ref: #547

---

## 체크리스트
- [x] 로컬 환경에서 빌드 및 기동 확인  
- [x] 배포 환경에서 컨테이너 정상 구동 및 DJL 로딩 로그 확인  
- [x] Dockerfile 변경 후 CI/CD 파이프라인 성공 확인  
- [x] 관련 문서(Dockerfile) 업데이트 완료  

---

## 상세 내용
```dockerfile
FROM eclipse-temurin:17-jre

RUN apt-get update && \
    apt-get install -y libstdc++6 tzdata && \
    ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
    echo "Asia/Seoul" > /etc/timezone && \
    rm -rf /var/lib/apt/lists/*

WORKDIR /app
RUN mkdir -p logs
COPY build/libs/*.jar app.jar
CMD ["java", "-jar", "app.jar"]
