### PR TITLE
[FE-#568] 챗봇 UI 개발 확인용 임시 라우트 추가

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import Signin from './pages/Mainpage/components/Signin';
 import AdminSignin from './pages/Mainpage/components/AdminSignin';
 import Signup from './pages/Mainpage/components/Signup';
 import { UserProvider } from './pages/Mainpage/handlers/UserContext';
+import Chatbot from './pages/Chatbot/Chatbot';
 import './main.css';
 
 function App() {
@@ -20,6 +21,7 @@ function App() {
       <Notification>
         <Router>
           <Routes>
+            {/* 기존 라우트들 */}
             <Route path="/" element={<MainPage />} />
             <Route path="/reservation/room" element={<StudyRoomBooking />} />
             <Route path="/adminpage" element={<Adminpage />} />
@@ -30,6 +32,8 @@ function App() {
             <Route path="/auth/signin" element={<Signin />} />
             <Route path="/auth/signup" element={<Signup />} />
             <Route path="/auth/admin-signin" element={<AdminSignin />} />
+            {/* 홈 페이지 버튼 연결 완료 후 제거 예정 */} 
+            <Route path="/chatbot" element={<Chatbot />} />
           </Routes>
         </Router> 
       </Notification>


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능

## 변경 사항

- 챗봇 페이지 UI 및 기능 개발을 확인하기 위한 임시 접근 라우트(/chatbot)를 App.jsx에 추가했습니다.
- 홈(MainPage) 수정 없이도 챗봇 화면을 독립적으로 확인할 수 있도록 구성했습니다.

## 관련 이슈
- #568 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- 본 PR은 개발 편의를 위한 임시 라우트 추가로
추후 홈 페이지 버튼 기반 이동이 완료되면 해당 라우트는 제거 또는 조정될 예정입니다.
- /chatbot 경로로 직접 접근하여 챗봇 UI 화면을 확인할 수 있습니다.

## 기타

- 홈 페이지 작업이 완료되기 전까지 챗봇 UI 개발 및 화면 확인을 위한 임시 수단입니다.
- 기능 영향 범위는 라우팅에 한정되어 있으며 기존 페이지 동작에는 영향을 주지 않습니다.

Close #568