### PR TITLE
[BE-#625] 에러 로그 추가

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/ranking/application/checkin/RankingCheckInApplicationService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/ranking/application/checkin/RankingCheckInApplicationService.java
@@ -10,8 +10,10 @@ import com.ice.studyroom.domain.reservation.domain.entity.Reservation;
 import com.ice.studyroom.domain.reservation.domain.type.ReservationStatus;
 import com.ice.studyroom.domain.schedule.domain.entity.Schedule;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RankingCheckInApplicationService {
@@ -39,6 +41,9 @@ public class RankingCheckInApplicationService {
 
 		// 랭킹 점수가 발생하지 않은 경우에는 랭킹 갱신 및 이벤트 처리가 필요 없으므로 return
 		if (score <= 0) {
+			log.debug("[RANKING] 점수 미발생 - reservationId: {}, memberId: {}",
+					reservation.getId(),
+					reservation.getMember().getId());
 			return;
 		}
 
@@ -47,43 +52,59 @@ public class RankingCheckInApplicationService {
 		// 이벤트 판단용 기준
 		RankingPeriod eventPeriod = RankingPeriod.WEEKLY;
 
-		// 점수 반영 전 rank
-		Integer previousRank = rankingStore.getRank(eventPeriod, memberId);
+        try {
 
-		// 기간별 전체 점수 반영
-		for (RankingPeriod period : RankingPeriod.values()) {
-			rankingStore.increaseScore(period, memberId, score);
-		}
+			log.info("[RANKING] 점수 반영 시작 - memberId: {}, score: {}",
+					memberId, score);
 
-		// 점수 반영 후 rank
-		Integer currentRank = rankingStore.getRank(eventPeriod, memberId);
+            // 점수 반영 전 rank
+            Integer previousRank = rankingStore.getRank(eventPeriod, memberId);
 
-		// 이전 랭킹이 없던 사용자의 경우 이벤트 발행 X
-		if (previousRank == null || currentRank == null) {
-			return;
-		}
+            // 기간별 전체 점수 반영
+            for (RankingPeriod period : RankingPeriod.values()) {
+                rankingStore.increaseScore(period, memberId, score);
+            }
 
-		Integer gapWithUpper = null;
-		Integer upperScore = rankingStore.getUpperScore(eventPeriod, memberId);
-		Integer myScore = rankingStore.getScore(eventPeriod, memberId);
+            // 점수 반영 후 rank
+            Integer currentRank = rankingStore.getRank(eventPeriod, memberId);
 
-		if (upperScore != null && myScore != null) {
-			gapWithUpper = upperScore - myScore;
-		}
+            // 이전 랭킹이 없던 사용자의 경우 이벤트 발행 X
+            if (previousRank == null || currentRank == null) {
+				log.debug("[RANKING] 기존 랭킹 없음 - memberId: {}", memberId);
 
-		// Context 생성
-		Member member = reservation.getMember();
+                return;
+            }
 
-		RankingContext context = new RankingContext(
-			memberId,
-			member.getName(),
-			member.getEmail().getValue(),
-			previousRank,
-			currentRank,
-			gapWithUpper
-		);
+            Integer gapWithUpper = null;
+            Integer upperScore = rankingStore.getUpperScore(eventPeriod, memberId);
+            Integer myScore = rankingStore.getScore(eventPeriod, memberId);
 
-		// 이벤트 트리거
-		rankingEventTriggerService.trigger(context);
-	}
+            if (upperScore != null && myScore != null) {
+                gapWithUpper = upperScore - myScore;
+            }
+
+            // Context 생성
+            Member member = reservation.getMember();
+
+            RankingContext context = new RankingContext(
+                memberId,
+                member.getName(),
+                member.getEmail().getValue(),
+                previousRank,
+                currentRank,
+                gapWithUpper
+            );
+
+            // 이벤트 트리거
+            rankingEventTriggerService.trigger(context);
+
+			log.info("[RANKING] ✅ 점수 반영 완료 - memberId: {}, 이전: {}, 현재: {}",
+					memberId, previousRank, currentRank);
+
+        } catch (Exception e) {
+
+			log.error("[RANKING] ❌ 점수 반영 중 오류 발생 - memberId: {}, score: {}",
+					memberId, score, e);
+        }
+    }
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/ranking/application/event/RankingEventTriggerService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/ranking/application/event/RankingEventTriggerService.java
@@ -1,10 +1,12 @@
 package com.ice.studyroom.domain.ranking.application.event;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import com.ice.studyroom.domain.ranking.domain.service.RankingEventPolicy;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RankingEventTriggerService {
@@ -17,16 +19,34 @@ public class RankingEventTriggerService {
 		rankingEventPolicy
 			.determine(context.previousRank(), context.currentRank())
 			.ifPresent(eventType -> {
-				RankingEmailEvent event = RankingEmailEvent.of(
-					eventType,
-					context.memberId(),
-					context.memberName(),
-					context.memberEmail(),
-					context.currentRank(),
-					context.previousRank(),
-					context.gapWithUpper()
-				);
-				rankingEventPublisher.publish(event);
-			});
+
+                try {
+
+					log.info("[RANKING] 랭킹 이벤트 발생 - memberId: {}, type: {}, 이전: {}, 현재: {}",
+							context.memberId(),
+							eventType,
+							context.previousRank(),
+							context.currentRank());
+
+                    RankingEmailEvent event = RankingEmailEvent.of(
+                        eventType,
+                        context.memberId(),
+                        context.memberName(),
+                        context.memberEmail(),
+                        context.currentRank(),
+                        context.previousRank(),
+                        context.gapWithUpper()
+                    );
+
+                    rankingEventPublisher.publish(event);
+
+                } catch (Exception e) {
+
+					log.error("[RANKING] ❌ 이벤트 발행 실패 - memberId: {}, type: {}",
+							context.memberId(),
+							eventType,
+							e);
+                }
+            });
 	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/ranking/application/snapshot/RankingSnapshotJob.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/ranking/application/snapshot/RankingSnapshotJob.java
@@ -3,14 +3,15 @@ package com.ice.studyroom.domain.ranking.application.snapshot;
 import com.ice.studyroom.domain.ranking.domain.service.RankingEntry;
 import com.ice.studyroom.domain.ranking.domain.service.RankingStore;
 import com.ice.studyroom.domain.ranking.domain.type.RankingPeriod;
-import com.ice.studyroom.domain.ranking.infrastructure.redis.RedisRankingStore;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RankingSnapshotJob {
@@ -21,16 +22,41 @@ public class RankingSnapshotJob {
 	@Transactional
 	public void execute(RankingPeriod period, String periodKey) {
 
-		List<RankingEntry> entries =
-			rankingStore.getAllRankings(period);
+		log.info("[RANKING] Snapshot 시작 - period: {}, periodKey: {}",
+				period, periodKey);
 
-		List<RankingSnapshotService.SnapshotData> snapshotData =
-			buildSnapshotData(entries);
+        try {
 
-		snapshotService.createSnapshot(period, periodKey, snapshotData);
+            List<RankingEntry> entries =
+                rankingStore.getAllRankings(period);
 
-		rankingStore.clear(period);
-	}
+			log.info("[RANKING] Snapshot 대상 건수 - period: {}, count: {}",
+					period, entries.size());
+
+			if (entries.isEmpty()) {
+				log.warn("[RANKING] Snapshot 대상 없음 - period: {}", period);
+			}
+
+            List<RankingSnapshotService.SnapshotData> snapshotData =
+                buildSnapshotData(entries);
+
+            snapshotService.createSnapshot(period, periodKey, snapshotData);
+
+			log.info("[RANKING] Snapshot 저장 완료 - period: {}, periodKey: {}",
+					period, periodKey);
+
+            rankingStore.clear(period);
+
+			log.info("[RANKING] Redis 초기화 완료 - period: {}",
+					period);
+
+        } catch (Exception e) {
+			log.error("[RANKING] ❌ Snapshot 실패 - period: {}, periodKey: {}",
+					period, periodKey, e);
+
+			throw e;
+        }
+    }
 
 	private List<RankingSnapshotService.SnapshotData> buildSnapshotData(
 		List<RankingEntry> entries

--- a/backend/src/main/java/com/ice/studyroom/domain/ranking/application/snapshot/RankingSnapshotService.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/ranking/application/snapshot/RankingSnapshotService.java
@@ -6,11 +6,13 @@ import com.ice.studyroom.domain.ranking.domain.type.RankingPeriod;
 import com.ice.studyroom.domain.ranking.infrastructure.persistence.RankingSnapshotItemRepository;
 import com.ice.studyroom.domain.ranking.infrastructure.persistence.RankingSnapshotRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -24,19 +26,38 @@ public class RankingSnapshotService {
 		String periodKey,
 		List<SnapshotData> snapshotDataList
 	) {
-		RankingSnapshot snapshot = rankingSnapshotRepository.save(
-			RankingSnapshot.create(period, periodKey));
+		try {
 
-		List<RankingSnapshotItem> items = snapshotDataList.stream()
-			.map(data -> RankingSnapshotItem.create(
-				snapshot.getId(),
-				data.memberId,
-				data.rank,
-				data.score
-			))
-			.toList();
+			log.info("[RANKING] Snapshot DB 저장 시작 - period: {}, periodKey: {}, size: {}",
+				period, periodKey, snapshotDataList.size());
 
-		rankingSnapshotItemRepository.saveAll(items);
+			RankingSnapshot snapshot = rankingSnapshotRepository.save(
+				RankingSnapshot.create(period, periodKey));
+
+			log.info("[RANKING] Snapshot 엔티티 저장 완료 - snapshotId: {}",
+				snapshot.getId());
+
+			List<RankingSnapshotItem> items = snapshotDataList.stream()
+				.map(data -> RankingSnapshotItem.create(
+					snapshot.getId(),
+					data.memberId,
+					data.rank,
+					data.score
+				))
+				.toList();
+
+			rankingSnapshotItemRepository.saveAll(items);
+
+			log.info("[RANKING] SnapshotItem 저장 완료 - snapshotId: {}, itemCount: {}",
+				snapshot.getId(), items.size());
+
+		} catch (Exception e) {
+
+			log.error("[RANKING] ❌ Snapshot DB 저장 실패 - period: {}, periodKey: {}",
+				period, periodKey, e);
+
+			throw e;
+		}
 	}
 
 	public record SnapshotData(

--- a/backend/src/main/java/com/ice/studyroom/domain/ranking/infrastructure/event/KafkaRankingEventPublisher.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/ranking/infrastructure/event/KafkaRankingEventPublisher.java
@@ -3,6 +3,7 @@ package com.ice.studyroom.domain.ranking.infrastructure.event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Component;
 
 import com.ice.studyroom.domain.ranking.application.event.RankingEmailEvent;
@@ -19,8 +20,22 @@ public class KafkaRankingEventPublisher implements RankingEventPublisher {
 
 	@Override
 	public void publish(RankingEmailEvent event) {
-		kafkaTemplate.send(TOPIC, event);
-		log.info("[KafkaRankingEventPublisher] event sent to topic: {}, eventId: {}",
-			TOPIC, event.eventId());
-		}
+		kafkaTemplate.send(TOPIC, event)
+			.whenComplete((result, ex) -> {
+
+				if (ex != null) {
+
+					log.error("[RANKING] ❌ Kafka 전송 실패 - topic: {}, eventId: {}",
+						TOPIC,
+						event.eventId(),
+						ex);
+
+				} else {
+
+					log.info("[RANKING] ✅ Kafka 전송 성공 - topic: {}, eventId: {}",
+						TOPIC,
+						event.eventId());
+				}
+			});
+	}
 }

--- a/backend/src/main/java/com/ice/studyroom/domain/ranking/infrastructure/redis/RedisRankingStore.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/ranking/infrastructure/redis/RedisRankingStore.java
@@ -4,6 +4,7 @@ import com.ice.studyroom.domain.ranking.domain.service.RankingEntry;
 import com.ice.studyroom.domain.ranking.domain.service.RankingStore;
 import com.ice.studyroom.domain.ranking.domain.type.RankingPeriod;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Set;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisRankingStore implements RankingStore {
@@ -23,9 +25,16 @@ public class RedisRankingStore implements RankingStore {
 
 	@Override
 	public void increaseScore(RankingPeriod period, Long memberId, int score) {
-		redisTemplate.opsForZSet()
-			.incrementScore(key(period), memberId.toString(), score);
-	}
+        try {
+            redisTemplate.opsForZSet()
+                .incrementScore(key(period), memberId.toString(), score);
+        } catch (Exception e) {
+			log.error("[RANKING] ❌ Redis 점수 증가 실패 - key: {}, memberId: {}, score: {}",
+					key(period), memberId, score, e);
+
+			throw e;
+        }
+    }
 
 	@Override
 	public Integer getScore(RankingPeriod period, Long memberId) {
@@ -65,33 +74,48 @@ public class RedisRankingStore implements RankingStore {
 	@Override
 	public Integer getRank(RankingPeriod period, Long memberId) {
 
-		Integer myScore = getScore(period, memberId);
-		if (myScore == null) return null;
+        try {
+            Integer myScore = getScore(period, memberId);
+            if (myScore == null) return null;
 
-		Long higherCount = redisTemplate.opsForZSet()
-				.count(key(period), myScore + 1, Double.POSITIVE_INFINITY);
+            Long higherCount = redisTemplate.opsForZSet()
+                    .count(key(period), myScore + 1, Double.POSITIVE_INFINITY);
 
-		return higherCount.intValue() + 1;
-	}
+            return higherCount.intValue() + 1;
+
+        } catch (Exception e) {
+			log.error("[RANKING] ❌ Redis 랭킹 조회 실패 - key: {}, memberId: {}",
+					key(period), memberId, e);
+
+			throw e;
+        }
+    }
 
 	@Override
 	public List<RankingEntry> getAllRankings(RankingPeriod period) {
 
-		Set<ZSetOperations.TypedTuple<String>> tuples =
-				redisTemplate.opsForZSet()
-						.reverseRangeWithScores(key(period), 0, -1);
+        try {
+            Set<ZSetOperations.TypedTuple<String>> tuples =
+                    redisTemplate.opsForZSet()
+                            .reverseRangeWithScores(key(period), 0, -1);
 
-		if (tuples == null || tuples.isEmpty()) {
-			return List.of();
-		}
+            if (tuples == null || tuples.isEmpty()) {
+                return List.of();
+            }
 
-		return tuples.stream()
-				.map(tuple -> new RankingEntry(
-						Long.valueOf(tuple.getValue()),
-						tuple.getScore().intValue()
-				))
-				.toList();
-	}
+            return tuples.stream()
+                    .map(tuple -> new RankingEntry(
+                            Long.valueOf(tuple.getValue()),
+                            tuple.getScore().intValue()
+                    ))
+                    .toList();
+        } catch (Exception e) {
+			log.error("[RANKING] ❌ Redis 전체 랭킹 조회 실패 - key: {}",
+					key(period), e);
+
+			throw e;
+        }
+    }
 
 	public void clear(RankingPeriod period) {
 		redisTemplate.delete(key(period));

--- a/backend/src/main/java/com/ice/studyroom/domain/ranking/scheduler/RankingScheduler.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/ranking/scheduler/RankingScheduler.java
@@ -3,6 +3,7 @@ package com.ice.studyroom.domain.ranking.scheduler;
 import com.ice.studyroom.domain.ranking.application.snapshot.RankingSnapshotJob;
 import com.ice.studyroom.domain.ranking.domain.type.RankingPeriod;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,6 +12,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.ZoneId;
 
+@Slf4j
 @Configuration
 @EnableScheduling
 @RequiredArgsConstructor
@@ -23,45 +25,115 @@ public class RankingScheduler {
 	// 주간 - 일요일 23:59:59
 	@Scheduled(cron = "59 59 23 ? * SUN", zone = KST_ZONE)
 	public void weeklySnapshot() {
-		snapshotJob.execute(
-			RankingPeriod.WEEKLY,
-			LocalDate.now(KST).toString()
-		);
-	}
+		String periodKey = LocalDate.now(KST).toString();
+
+		log.info("[RANKING] Weekly Snapshot 스케줄 시작 - periodKey: {}", periodKey);
+
+        try {
+            snapshotJob.execute(
+                RankingPeriod.WEEKLY,
+                    periodKey
+            );
+			log.info("[RANKING] ✅ Weekly Snapshot 스케줄 완료 - periodKey: {}", periodKey);
+
+        } catch (Exception e) {
+
+			log.error("[RANKING] ❌ Weekly Snapshot 스케줄 실패 - periodKey: {}",
+					periodKey, e);
+
+			throw e;
+        }
+    }
 
 	// 월간 - 말일 23:59:59
 	@Scheduled(cron = "59 59 23 L * ?", zone = KST_ZONE)
 	public void monthlySnapshot() {
-		snapshotJob.execute(
-			RankingPeriod.MONTHLY,
-			YearMonth.now(KST).toString()
-		);
-	}
+		String periodKey = YearMonth.now(KST).toString();
+
+		log.info("[RANKING] Monthly Snapshot 시작 - periodKey: {}", periodKey);
+
+        try {
+            snapshotJob.execute(
+                RankingPeriod.MONTHLY,
+                    periodKey
+            );
+			log.info("[RANKING] ✅ Monthly Snapshot 완료 - periodKey: {}", periodKey);
+
+        } catch (Exception e) {
+
+			log.error("[RANKING] ❌ Monthly Snapshot 실패 - periodKey: {}",
+					periodKey, e);
+
+			throw e;
+        }
+    }
 
 	// 연간 - 12월 31일 23:59:59
 	@Scheduled(cron = "59 59 23 31 12 ?", zone = KST_ZONE)
 	public void yearlySnapshot() {
-		snapshotJob.execute(
-			RankingPeriod.YEARLY,
-			String.valueOf(LocalDate.now(KST).getYear())
-		);
-	}
+		String periodKey = String.valueOf(LocalDate.now(KST).getYear());
+
+		log.info("[RANKING] Yearly Snapshot 시작 - periodKey: {}", periodKey);
+
+        try {
+            snapshotJob.execute(
+                RankingPeriod.YEARLY,
+                    periodKey
+            );
+			log.info("[RANKING] ✅ Yearly Snapshot 완료 - periodKey: {}", periodKey);
+
+        } catch (Exception e) {
+
+			log.error("[RANKING] ❌ Yearly Snapshot 실패 - periodKey: {}",
+					periodKey, e);
+
+			throw e;
+        }
+    }
 
 	// 1학기 - 매년 7월 1일 00:00
 	@Scheduled(cron = "0 0 0 1 7 ?", zone = KST_ZONE)
 	public void firstSemesterSnapshot() {
-		snapshotJob.execute(
-				RankingPeriod.SEMESTER,
-				LocalDate.now(KST).getYear() + "-1"
-		);
-	}
+		String periodKey = LocalDate.now(KST).getYear() + "-1";
+
+		log.info("[RANKING] First Semester Snapshot 시작 - periodKey: {}", periodKey);
+
+        try {
+            snapshotJob.execute(
+                    RankingPeriod.SEMESTER,
+                    periodKey
+            );
+			log.info("[RANKING] ✅ First Semester Snapshot 완료 - periodKey: {}", periodKey);
+
+        } catch (Exception e) {
+
+			log.error("[RANKING] ❌ First Semester Snapshot 실패 - periodKey: {}",
+					periodKey, e);
+
+			throw e;
+        }
+    }
 
 	// 2학기 - 매년 11월 1일 00:00
 	@Scheduled(cron = "0 0 0 1 11 ?", zone = KST_ZONE)
 	public void secondSemesterSnapshot() {
-		snapshotJob.execute(
-				RankingPeriod.SEMESTER,
-				LocalDate.now(KST).getYear() + "-2"
-		);
-	}
+		String periodKey = LocalDate.now(KST).getYear() + "-2";
+
+		log.info("[RANKING] Second Semester Snapshot 시작 - periodKey: {}", periodKey);
+
+        try {
+            snapshotJob.execute(
+                    RankingPeriod.SEMESTER,
+                    periodKey
+            );
+			log.info("[RANKING] ✅ Second Semester Snapshot 완료 - periodKey: {}", periodKey);
+
+        } catch (Exception e) {
+
+			log.error("[RANKING] ❌ Second Semester Snapshot 실패 - periodKey: {}",
+					periodKey, e);
+
+			throw e;
+        }
+    }
 }


### PR DESCRIPTION
## PR 종류
- [x] 리팩토링

## 변경 사항
- 랭킹 도메인 전반에 로깅 정책 적용
- RankingCheckInApplicationService 예외 처리 및 ERROR 로그 추가
- RankingEventTriggerService 이벤트 발행 실패 로깅 추가
- KafkaRankingEventPublisher 비동기 전송 실패 로깅 보강
- RedisRankingStore 주요 연산(increaseScore, getRank, getAllRankings) 예외 로깅 추가
- SnapshotJob / SnapshotService DB 저장 실패 시 ERROR 로그 및 throw 전파
- RankingScheduler 스케줄 시작/성공/실패 로그 추가

## 관련 이슈
- #625 

## 체크리스트
- [x] 테스트 코드를 작성하였나요? (기존 테스트 영향 없음 확인)
- [x] 모든 테스트가 통과하나요?
- [x] 코드 컨벤션을 지켰나요?
- [x] 관련 문서를 업데이트했나요?

## 상세 내용

| 상황 | 로그 레벨 |
|------|-----------|
| 점수 정상 반영 | INFO |
| 랭킹 변동 감지 | INFO |
| Kafka 이벤트 발행 실패 | ERROR |
| Redis 연산 실패 | ERROR |
| Snapshot 저장 실패 | ERROR |
| 내부 로직 오류 | ERROR |

- Application 레이어: 비즈니스 성공을 방해하지 않도록 예외 로깅 후 삼킴
- Infrastructure 레이어: 인프라 오류는 ERROR 로그 후 throw
- Snapshot/스케줄러: 데이터 무결성 보장을 위해 ERROR 로그 후 throw