### PR TITLE
[BE-#628] NotificationResponse 응답 DTO에 notificationId 추가

### DIFF
--- a/backend/src/main/java/com/ice/studyroom/domain/notification/presentation/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/ice/studyroom/domain/notification/presentation/dto/response/NotificationResponse.java
@@ -10,17 +10,17 @@ import java.time.LocalDateTime;
 @Builder
 public class NotificationResponse {
 
+	private Long id;
 	private String eventType;
-
 	private int rank;
 	private Integer previousRank;
 	private Integer gapWithUpper;
-
 	private boolean isRead;
 	private LocalDateTime createdAt;
 
 	public static NotificationResponse from(Notification notification) {
 		return NotificationResponse.builder()
+			.id(notification.getId())
 			.eventType(notification.getEventType().name())
 			.rank(notification.getRank())
 			.previousRank(notification.getPreviousRank())


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선

## 변경 사항

- 알림 조회 API 응답에 notificationId가 포함되지 않아, 프론트에서 개별 알림을 식별할 수 없었음
- 알림 삭제 기능 호출 시 특정 알림을 지정할 수 없는 문제 발생

## 관련 이슈

- BE-#628

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
➡️main에 머지 이후에 노션 api 명세서 업데이트 진행하겠습니다.
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- NotificationResponse에 `id` 필드 추가
- NotificationResponse.from()에서 notification.getId() 매핑 추가
- 조회 응답에 알림 고유 id가 포함되도록 수정

## 기타

- 스웨거로 테스트 완료했습니다. (200 성공)
- 기존 응답에는 id가 반환되지 않았지만 수정 이후에 알람 별 id가 응답에 포함되어 전송됩니다.
<img width="455" height="552" alt="스크린샷 2026-02-23 001634" src="https://github.com/user-attachments/assets/f05e7623-d104-4511-acd7-e08da4a2b773" />


Close #628 
